### PR TITLE
Match encoder settings to input

### DIFF
--- a/lib/round_transcoder.js
+++ b/lib/round_transcoder.js
@@ -1,6 +1,7 @@
 const fs = require('fs');
 const Promise = require('bluebird');
 const lame = require('lame');
+const mm = require('music-metadata');
 
 class RoundTranscoder {
   constructor(roundManager) {
@@ -9,37 +10,53 @@ class RoundTranscoder {
 
   async transcode() {
     let transcoderPromises = this.roundManager.songs.map((song) => {
-      return new Promise((resolve) => {
-        let transcodePath = `${this.roundManager.dirs.transcode}/${song.filename()}`;
-        let finalPath = `${this.roundManager.dirs.final}/${song.filename()}`;
+      return this.transcodeSong(song);
+    });
 
-        let readStream = fs.createReadStream(song.paths.download);
-        let decodeStream = new lame.Decoder();
-        let encodeStream = new lame.Encoder({
-          // input
-          channels: 2,        // 2 channels (left and right)
-          bitDepth: 16,       // 16-bit samples
-          sampleRate: 44100,  // 44,100 Hz sample rate
+    await Promise.all(transcoderPromises);
+  }
 
-          // output
-          bitRate: 320,
-          outSampleRate: 44100,
-          mode: lame.STEREO
-        });
-        let writeStream = fs.createWriteStream(transcodePath);
+  async transcodeSong(song) {
+    let metadata = await mm.parseFile(song.paths.download);
 
-        let pipe = readStream.pipe(decodeStream).pipe(encodeStream).pipe(writeStream);
+    // The eslint rule here is trying to prevent accidental race conditions,
+    // because we're accessing data on song and then setting it based on the
+    // result of the await here. This should be fine because we can't get to
+    // the transcode step until all of the download step is complete, and
+    // nothing can get the metadata until the entire transcode step is done.
+    // eslint-disable-next-line require-atomic-updates
+    song.metadata = metadata;
 
-        pipe.on('finish', () => {
-          fs.rename(transcodePath, finalPath, () => {
-            song.paths.final = finalPath;
-            resolve();
-          });
+    let transcodePromise = new Promise((resolve) => {
+      let transcodePath = `${this.roundManager.dirs.transcode}/${song.filename()}`;
+      let finalPath = `${this.roundManager.dirs.final}/${song.filename()}`;
+
+      let readStream = fs.createReadStream(song.paths.download);
+      let decodeStream = new lame.Decoder();
+      let encodeStream = new lame.Encoder({
+        // input
+        channels: metadata.format.numberOfChannels,
+        bitDepth: 16,
+        sampleRate: metadata.format.sampleRate,
+
+        // output
+        bitRate: 320,
+        outSampleRate: 44100,
+        mode: lame.STEREO
+      });
+      let writeStream = fs.createWriteStream(transcodePath);
+
+      let pipe = readStream.pipe(decodeStream).pipe(encodeStream).pipe(writeStream);
+
+      pipe.on('finish', () => {
+        fs.rename(transcodePath, finalPath, () => {
+          song.paths.final = finalPath;
+          resolve();
         });
       });
     });
 
-    await Promise.all(transcoderPromises);
+    await transcodePromise;
   }
 }
 

--- a/lib/song.js
+++ b/lib/song.js
@@ -4,6 +4,7 @@ class Song {
     this.title = title;
     this.artist = artist;
     this.url = url;
+    this.metadata = null;
 
     this.paths = {
       download: null,

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "hubot-scripts": "^2.17.2",
     "hubot-shipit": "^0.2.1",
     "lame": "^1.2.4",
+    "music-metadata": "^4.8.0",
     "node-fetch": "^2.6.0",
     "nodeshout": "^0.1.3",
     "request": "^2.88.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -324,7 +324,7 @@ content-disposition@0.5.3:
   dependencies:
     safe-buffer "5.1.2"
 
-content-type@~1.0.4:
+content-type@^1.0.4, content-type@~1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.4.tgz#e138cc75e040c727b1966fe5e5f8c9aee256fe3b"
   integrity sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==
@@ -392,7 +392,7 @@ debug@2, debug@2.6.9, debug@^2.2.0:
   dependencies:
     ms "2.0.0"
 
-debug@^4.0.1:
+debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
   integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
@@ -772,6 +772,11 @@ file-entry-cache@^5.0.1:
   integrity sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==
   dependencies:
     flat-cache "^2.0.1"
+
+file-type@^12.1.0:
+  version "12.3.0"
+  resolved "https://registry.yarnpkg.com/file-type/-/file-type-12.3.0.tgz#74d755e5dc9c5cbc7ee6f182529b453906ac88c2"
+  integrity sha512-4E4Esq9KLwjYCY32E7qSmd0h7LefcniZHX+XcdJ4Wfx1uGJX7QCigiqw/U0yT7WOslm28yhxl87DJ0wHYv0RAA==
 
 file-uri-to-path@1.0.0:
   version "1.0.0"
@@ -1275,6 +1280,11 @@ media-typer@0.3.0:
   resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
   integrity sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=
 
+media-typer@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-1.1.0.tgz#6ab74b8f2d3320f2064b2a87a38e7931ff3a5561"
+  integrity sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==
+
 merge-descriptors@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/merge-descriptors/-/merge-descriptors-1.0.1.tgz#b00aaa556dd8b44568150ec9d1b953f3f90cbb61"
@@ -1350,6 +1360,18 @@ multiparty@~4.2.1:
     http-errors "~1.7.0"
     safe-buffer "5.1.2"
     uid-safe "2.1.5"
+
+music-metadata@^4.8.0:
+  version "4.8.0"
+  resolved "https://registry.yarnpkg.com/music-metadata/-/music-metadata-4.8.0.tgz#5bf1d8afe8f0cdc652847b7a39cb95d61982c179"
+  integrity sha512-eQp9mDTwg8WEqVRIEj1lUuqZ4qiQvXa71ipotkPFKch4ekTAtGTzU/TXAi7DhCeHsZB8WLfGUBTFN1NGBE1iOQ==
+  dependencies:
+    content-type "^1.0.4"
+    debug "^4.1.0"
+    file-type "^12.1.0"
+    media-typer "^1.1.0"
+    strtok3 "^3.0.1"
+    token-types "^1.0.3"
 
 mute-stream@0.0.7:
   version "0.0.7"
@@ -1870,6 +1892,15 @@ strip-json-comments@^3.0.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.0.1.tgz#85713975a91fb87bf1b305cca77395e40d2a64a7"
   integrity sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw==
 
+strtok3@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/strtok3/-/strtok3-3.0.1.tgz#67b67c318b44f9fbff97fd94033681ec502fdfa2"
+  integrity sha512-1aRPsZAxNJ8xo0UPpJgI7VRLZsjal0lvjkF4kIvHL6u3RxHM+hbenfJA0hVmwoUcjbvHuo/HqeB+tTUYx2FciA==
+  dependencies:
+    debug "^4.1.1"
+    then-read-stream "^2.0.6"
+    token-types "^1.0.1"
+
 supports-color@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
@@ -1897,6 +1928,11 @@ text-table@^0.2.0:
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
   integrity sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=
 
+then-read-stream@^2.0.6:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/then-read-stream/-/then-read-stream-2.0.6.tgz#8d8e2b165b54a1c5f866cb43e2164c1f5f9b85ac"
+  integrity sha512-5HA8j7O3NL6P4Pi0IzZx8/t46sK0+h3n+P/P0Yzi11ODwR+ZWjG+KILzLXPvJM7PvYjK7sDKfcN1YVCNGbPNEQ==
+
 through@^2.3.6:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
@@ -1913,6 +1949,11 @@ toidentifier@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.0.tgz#7e1be3470f1e77948bc43d94a3c8f4d7752ba553"
   integrity sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==
+
+token-types@^1.0.1, token-types@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/token-types/-/token-types-1.0.3.tgz#737cc01939d23577ae339b88de82fa3cb3d0b735"
+  integrity sha512-8THi5oekS/TLE01xOMknevTgHwVEcWOsO3zlqxGvzAz+tjZGiACyjcZuH1LTJuHvqmb8SsX/BeqcfQA0JRwqzA==
 
 tough-cookie@~2.4.3:
   version "2.4.3"


### PR DESCRIPTION
Now we read in metadata on the song and correctly set the number of channels and sample rate of the incoming PCM in the encoder stream.

Without that, mono tracks got all sorts of messed up during encoding - double speed, higher-pitched likely due to the speedup.