### PR TITLE
Programmatic Announcer, fixes #14

### DIFF
--- a/.profile
+++ b/.profile
@@ -1,2 +1,2 @@
 # add vendor binaries to the path
-export PATH=/app/vendor/sox/bin/sox:$PATH
+export PATH=/app/vendor/sox/bin:$PATH

--- a/.profile
+++ b/.profile
@@ -1,0 +1,2 @@
+# add vendor binaries to the path
+export PATH=/app/vendor/sox/bin/sox:$PATH

--- a/.vendor_urls
+++ b/.vendor_urls
@@ -1,0 +1,1 @@
+https://s3.amazonaws.com/thasauce_heroku/packages/heroku-18/sox-vendor-14.4.2.tar.gz

--- a/Aptfile
+++ b/Aptfile
@@ -1,1 +1,1 @@
-libshout3 libshout3-dev lame sox libsox-fmt-mp3 libsox-fmt-all
+libshout3 libshout3-dev libsndfile1 libsndfile1-dev libmad0 libmad0-dev libmp3lame0 libmp3lame-dev

--- a/Aptfile
+++ b/Aptfile
@@ -1,1 +1,2 @@
-libshout3 libshout3-dev lame libsox-fmt-mp3 libsox-fmt-all sox
+libshout3 libshout3-dev lame libsox-fmt-mp3 libsox-fmt-all
+sox

--- a/Aptfile
+++ b/Aptfile
@@ -1,1 +1,1 @@
-libshout3 libshout3-dev lame libsox-fmt-mp3 libsox-fmt-all sox
+libshout3 libshout3-dev

--- a/Aptfile
+++ b/Aptfile
@@ -1,2 +1,1 @@
-libshout3 libshout3-dev lame libsox-fmt-mp3 libsox-fmt-all
-sox
+libshout3 libshout3-dev lame libsox-fmt-mp3 libsox-fmt-all sox

--- a/Aptfile
+++ b/Aptfile
@@ -1,1 +1,1 @@
-libshout3 libshout3-dev sox lame
+libshout3 libshout3-dev sox lame libsox-fmt-mp3

--- a/Aptfile
+++ b/Aptfile
@@ -1,1 +1,1 @@
-libshout3 libshout3-dev sox
+libshout3 libshout3-dev sox lame

--- a/Aptfile
+++ b/Aptfile
@@ -1,1 +1,1 @@
-libshout3 libshout3-dev
+libshout3 libshout3-dev lame libsox-fmt-mp3 libsox-fmt-all libpng12

--- a/Aptfile
+++ b/Aptfile
@@ -1,1 +1,1 @@
-libshout3 libshout3-dev
+libshout3 libshout3-dev sox

--- a/Aptfile
+++ b/Aptfile
@@ -1,1 +1,1 @@
-libshout3 libshout3-dev lame libsox-fmt-mp3 libsox-fmt-all libpng12
+libshout3 libshout3-dev lame sox libsox-fmt-mp3 libsox-fmt-all

--- a/Aptfile
+++ b/Aptfile
@@ -1,1 +1,1 @@
-libshout3 libshout3-dev sox lame libsox-fmt-mp3
+libshout3 libshout3-dev lame libsox-fmt-mp3 libsox-fmt-all sox

--- a/VENDOR_INSTALL.md
+++ b/VENDOR_INSTALL.md
@@ -1,0 +1,29 @@
+# Compiling and installing vendor libraries
+
+```
+docker run -it --name thasauce-build heroku/heroku:18-build bash
+
+mkdir /app
+cd /app
+
+apt-get update
+apt-get install libsndfile1 libsndfile1-dev libmad0 libmad0-dev libmp3lame0 libmp3lame-dev
+wget https://sourceforge.net/projects/sox/files/sox/14.4.2/sox-14.4.2.tar.gz/download -O sox-14.4.2.tar.gz
+tar xzf sox-14.4.2.tar.gz
+cd sox-14.4.2
+./configure --prefix=/app/vendor/sox
+make -s
+make install
+
+cd /app
+tar czf sox-vendor-14.4.2.tar.gz vendor/sox/
+
+# In another terminal
+docker cp thasauce-build:/app/sox-vendor-14.4.2.tar.gz .
+
+# In original terminal
+exit
+docker rm thasauce-build
+
+# Host them on S3, and add them to .vendor_urls
+```

--- a/lib/round_announcer.js
+++ b/lib/round_announcer.js
@@ -1,9 +1,15 @@
 const fs = require('fs');
+const stream = require('stream');
+const util = require('util');
+
 const AWS = require('aws-sdk');
 const Promise = require('bluebird');
 const lame = require('lame');
-const sox = require('sox.js');
+const soxCallback = require('sox.js');
 const streamifier = require('streamifier');
+
+const pipeline = util.promisify(stream.pipeline);
+const sox = util.promisify(soxCallback);
 
 class RoundAnnouncer {
   constructor(roundManager) {
@@ -21,88 +27,80 @@ class RoundAnnouncer {
   }
 
   async processSong(song) {
-    let promise = new Promise((resolve, reject) => {
-      let polly = new AWS.Polly();
-      let awsPath = `${this.roundManager.dirs.announcer}/${song.filename({ type: 'announcer-aws' })}`;
-      let pcmPath = `${this.roundManager.dirs.announcer}/${song.filename({ type: 'announcer-pcm' })}`;
-      let finalPath = `${this.roundManager.dirs.announcer}/${song.filename()}`;
+    let polly = new AWS.Polly();
+    let awsPath = `${this.roundManager.dirs.announcer}/${song.filename({ type: 'announcer-aws' })}`;
+    let pcmPath = `${this.roundManager.dirs.announcer}/${song.filename({ type: 'announcer-pcm' })}`;
+    let finalPath = `${this.roundManager.dirs.announcer}/${song.filename()}`;
 
-      // TODO: use randomization and song position to make this more dynamic
-      let text = `Next up: ${song.title} by ${song.artist}`;
+    // TODO: use randomization and song position to make this more dynamic
+    let text = `Next up: ${song.title} by ${song.artist}`;
 
-      let params = {
-        OutputFormat: 'mp3',
-        Text: text,
-        VoiceId: 'Joanna',
-        Engine: 'neural',
-        SampleRate: '24000',
-        TextType: 'text'
-      };
-      polly.synthesizeSpeech(params).promise().then((response) => {
-        let readStream = streamifier.createReadStream(response.AudioStream);
-        let writeStream = fs.createWriteStream(awsPath);
+    let params = {
+      OutputFormat: 'mp3',
+      Text: text,
+      VoiceId: 'Joanna',
+      Engine: 'neural',
+      SampleRate: '24000',
+      TextType: 'text'
+    };
+    let response = await polly.synthesizeSpeech(params).promise();
+    let pollyReadStream = streamifier.createReadStream(response.AudioStream);
+    let pcmWriteStream = fs.createWriteStream(awsPath);
 
-        let pipe = readStream.pipe(writeStream);
+    await pipeline(pollyReadStream, pcmWriteStream);
 
-        pipe.on('finish', () => {
-          sox({
-            inputFile: awsPath,
-            input: {
-              type: 'mp3'
-            },
-            outputFile: pcmPath,
-            output: {
-              bits: 16,
-              channels: 2,
-              rate: 44100,
-              type: 'raw'
-            }
-          }, (err) => {
-            // If we get an error back from running sox (and it isn't just a warning)
-            // then reject the promise.
-            if (err && !err.message.startsWith('sox WARN')) {
-              reject(err);
-              return;
-            }
+    let soxParams = {
+      inputFile: awsPath,
+      input: {
+        type: 'mp3'
+      },
+      outputFile: pcmPath,
+      output: {
+        bits: 16,
+        channels: 2,
+        rate: 44100,
+        type: 'raw'
+      }
+    };
 
-            let readStream = fs.createReadStream(pcmPath);
-            let encodeStream = new lame.Encoder({
-              // input
-              bitDepth: 16,
-              channels: 2,
-              sampleRate: 44100,
-
-              // output
-              bitRate: 320,
-              outSampleRate: 44100,
-              mode: lame.JOINTSTEREO
-            });
-            let writeStream = fs.createWriteStream(finalPath);
-
-            let pipe = readStream.pipe(encodeStream).pipe(writeStream);
-
-            pipe.on('finish', () => {
-              fs.unlink(awsPath, (err) => {
-                if (err) {
-                  reject(err);
-                }
-
-                fs.unlink(pcmPath, (err) => {
-                  if (err) {
-                    reject(err);
-                  }
-
-                  song.paths.announcer = finalPath;
-                  resolve();
-                });
-              });
-            });
-          });
-        });
-      });
+    await sox(soxParams).catch((err) => {
+      // If we get an error back from running sox (and it isn't just a warning)
+      // then throw an error.
+      if (err && !err.message.startsWith('sox WARN')) {
+        if (err instanceof Error) {
+          throw err;
+        } else {
+          // If it's not an error instance, assume it is a string we should wrap with an Error
+          throw new Error(err);
+        }
+      }
     });
 
-    await promise;
+    let pcmReadStream = fs.createReadStream(pcmPath);
+    let encodeStream = new lame.Encoder({
+      // input
+      bitDepth: 16,
+      channels: 2,
+      sampleRate: 44100,
+
+      // output
+      bitRate: 320,
+      outSampleRate: 44100,
+      mode: lame.JOINTSTEREO
+    });
+    let mp3WriteStream = fs.createWriteStream(finalPath);
+
+    await pipeline(
+      pcmReadStream,
+      encodeStream,
+      mp3WriteStream
+    );
+
+    await fs.promises.unlink(awsPath);
+    await fs.promises.unlink(pcmPath);
+
+    // eslint-disable-next-line require-atomic-updates
+    song.paths.announcer = finalPath;
   }
 }
 

--- a/lib/round_announcer.js
+++ b/lib/round_announcer.js
@@ -27,6 +27,7 @@ class RoundAnnouncer {
       let pcmPath = `${this.roundManager.dirs.announcer}/${song.filename({ type: 'announcer-pcm' })}`;
       let finalPath = `${this.roundManager.dirs.announcer}/${song.filename()}`;
 
+      // TODO: use randomization and song position to make this more dynamic
       let text = `Next up: ${song.title} by ${song.artist}`;
 
       let params = {

--- a/lib/round_announcer.js
+++ b/lib/round_announcer.js
@@ -1,0 +1,114 @@
+const fs = require('fs');
+const AWS = require('aws-sdk');
+const Promise = require('bluebird');
+const lame = require('lame');
+const sox = require('sox.js');
+const streamifier = require('streamifier');
+
+class RoundAnnouncer {
+  constructor(roundManager) {
+    this.roundManager = roundManager;
+  }
+
+  async process() {
+    // TODO: we're potentially processing too many of these at once and hitting
+    // AWS rate limits. Rewrite slightly to use https://www.npmjs.com/package/bottleneck
+    let processPromises = this.roundManager.songs.map((song) => {
+      return this.processSong(song);
+    });
+
+    await Promise.all(processPromises);
+  }
+
+  async processSong(song) {
+    let promise = new Promise((resolve, reject) => {
+      let polly = new AWS.Polly();
+      let awsPath = `${this.roundManager.dirs.announcer}/${song.filename({ type: 'announcer-aws' })}`;
+      let pcmPath = `${this.roundManager.dirs.announcer}/${song.filename({ type: 'announcer-pcm' })}`;
+      let finalPath = `${this.roundManager.dirs.announcer}/${song.filename()}`;
+
+      console.log({
+        awsPath,
+        pcmPath,
+        finalPath
+      });
+
+      let text = `Next up: ${song.title} by ${song.artist}`;
+
+      let params = {
+        OutputFormat: 'mp3',
+        Text: text,
+        VoiceId: 'Joanna',
+        Engine: 'neural',
+        SampleRate: '24000',
+        TextType: 'text'
+      };
+      polly.synthesizeSpeech(params).promise().then((response) => {
+        let readStream = streamifier.createReadStream(response.AudioStream);
+        let writeStream = fs.createWriteStream(awsPath);
+
+        let pipe = readStream.pipe(writeStream);
+
+        pipe.on('finish', () => {
+          sox({
+            inputFile: awsPath,
+            input: {
+              type: 'mp3'
+            },
+            outputFile: pcmPath,
+            output: {
+              bits: 16,
+              channels: 2,
+              rate: 44100,
+              type: 'raw'
+            }
+          }, (err) => {
+            // If we get an error back from running sox (and it isn't just a warning)
+            // then reject the promise.
+            if (err && !err.message.startsWith('sox WARN')) {
+              reject(err);
+              return;
+            }
+
+            let readStream = fs.createReadStream(pcmPath);
+            let encodeStream = new lame.Encoder({
+              // input
+              bitDepth: 16,
+              channels: 2,
+              sampleRate: 44100,
+
+              // output
+              bitRate: 320,
+              outSampleRate: 44100,
+              mode: lame.JOINTSTEREO
+            });
+            let writeStream = fs.createWriteStream(finalPath);
+
+            let pipe = readStream.pipe(encodeStream).pipe(writeStream);
+
+            pipe.on('finish', () => {
+              fs.unlink(awsPath, (err) => {
+                if (err) {
+                  reject(err);
+                }
+
+                fs.unlink(pcmPath, (err) => {
+                  if (err) {
+                    reject(err);
+                  }
+
+                  song.paths.announcer = finalPath;
+                  resolve();
+                });
+              });
+            });
+          });
+        });
+      });
+    });
+
+    await promise;
+  }
+}
+
+module.exports = RoundAnnouncer;

--- a/lib/round_announcer.js
+++ b/lib/round_announcer.js
@@ -27,12 +27,6 @@ class RoundAnnouncer {
       let pcmPath = `${this.roundManager.dirs.announcer}/${song.filename({ type: 'announcer-pcm' })}`;
       let finalPath = `${this.roundManager.dirs.announcer}/${song.filename()}`;
 
-      console.log({
-        awsPath,
-        pcmPath,
-        finalPath
-      });
-
       let text = `Next up: ${song.title} by ${song.artist}`;
 
       let params = {

--- a/lib/round_announcer.js
+++ b/lib/round_announcer.js
@@ -4,6 +4,7 @@ const util = require('util');
 
 const AWS = require('aws-sdk');
 const Promise = require('bluebird');
+const Bottleneck = require('bottleneck');
 const lame = require('lame');
 const soxCallback = require('sox.js');
 const streamifier = require('streamifier');
@@ -17,10 +18,13 @@ class RoundAnnouncer {
   }
 
   async process() {
-    // TODO: we're potentially processing too many of these at once and hitting
-    // AWS rate limits. Rewrite slightly to use https://www.npmjs.com/package/bottleneck
+    let limiter = new Bottleneck({
+      maxConcurrent: 3,
+      minTime: 333
+    });
+
     let processPromises = this.roundManager.songs.map((song) => {
-      return this.processSong(song);
+      return limiter.schedule(() => this.processSong(song));
     });
 
     await Promise.all(processPromises);

--- a/lib/round_fetcher.js
+++ b/lib/round_fetcher.js
@@ -1,7 +1,11 @@
 const fs = require('fs');
-const { pipeline } = require('stream');
-const needle = require('needle');
+const stream = require('stream');
+const util = require('util');
+
 const Promise = require('bluebird');
+const needle = require('needle');
+
+const pipeline = util.promisify(stream.pipeline);
 
 class RoundFetcher {
   constructor(roundManager) {
@@ -10,53 +14,51 @@ class RoundFetcher {
 
   async fetch() {
     let downloadPromises = this.roundManager.songs.map((song) => {
-      return new Promise((resolve, reject) => {
-        let downloadPath = `${this.roundManager.dirs.download}/${song.filename()}`;
-        let writeStream = fs.createWriteStream(downloadPath);
-        let requestStream = needle.get(song.url, {
-          // ._. why snakecase, needle? why?
-          // eslint-disable-next-line camelcase
-          response_timeout: 30000,
-          // eslint-disable-next-line camelcase
-          read_timeout: 30000
-        });
-
-        console.info(`FETCH[START]: Downloading ${song.id} to ${downloadPath}`.info);
-
-        // I hate that I have to do this.
-        // I seem to be getting inconsistent emitted errors below, so I want to make sure we only ever report
-        // and reject the promise on the first one.
-        // Next, I should try using node-fetch and see if it is more consistent so we can drop this.
-        let rejected = false;
-        let handleError = (err, msg) => {
-          if (rejected) {
-            return;
-          }
-          console.error(msg.error);
-          reject(err);
-          rejected = true;
-        };
-
-        requestStream.on('timeout', (err) => handleError(err, `FETCH[TIMEOUT]: Downloading ${song.id} from ${song.url} to ${downloadPath}`));
-        requestStream.on('err', (err) => handleError(err, `FETCH[ERROR]: Downloading ${song.id} from ${song.url} to ${downloadPath}`));
-
-        pipeline(
-          requestStream,
-          writeStream,
-          (err) => {
-            if (err) {
-              handleError(err, `FETCH[ERROR]: Downloading ${song.id} from ${song.url} to ${downloadPath}`);
-            } else if (!rejected) {
-              console.info(`FETCH[FINISH]: Downloaded to ${downloadPath}`.success);
-              song.paths.download = downloadPath;
-              resolve();
-            }
-          }
-        );
-      });
+      return this.fetchSong(song);
     });
 
     await Promise.all(downloadPromises);
+  }
+
+  async fetchSong(song) {
+    let downloadPath = `${this.roundManager.dirs.download}/${song.filename()}`;
+    let writeStream = fs.createWriteStream(downloadPath);
+    let requestStream = needle.get(song.url, {
+      // ._. why snakecase, needle? why?
+      // eslint-disable-next-line camelcase
+      response_timeout: 30000,
+      // eslint-disable-next-line camelcase
+      read_timeout: 30000
+    });
+
+    console.info(`FETCH[START]: Downloading ${song.id} to ${downloadPath}`.info);
+
+    // I hate that I have to do this.
+    // I seem to be getting inconsistent emitted errors below, so I want to make sure we only ever report
+    // and reject the promise on the first one.
+    // Next, I should try using node-fetch and see if it is more consistent so we can drop this.
+    let handleError = (err, msg) => {
+      console.error(msg.error);
+      if (err instanceof Error) {
+        throw err;
+      } else {
+        // If it's not an error instance, assume it is a string we should wrap with an Error
+        throw new Error(err);
+      }
+    };
+
+    // throw new Error('test fetch error');
+
+    requestStream.on('timeout', (err) => handleError(err, `FETCH[TIMEOUT]: Downloading ${song.id} from ${song.url} to ${downloadPath}`));
+    requestStream.on('err', (err) => handleError(err, `FETCH[ERROR]: Downloading ${song.id} from ${song.url} to ${downloadPath}`));
+
+    await pipeline(requestStream, writeStream).catch((err) => {
+      handleError(err, `FETCH[ERROR]: Downloading ${song.id} from ${song.url} to ${downloadPath}`);
+    });
+
+    console.info(`FETCH[FINISH]: Downloaded to ${downloadPath}`.success);
+    // eslint-disable-next-line require-atomic-updates
+    song.paths.download = downloadPath;
   }
 }
 

--- a/lib/round_fetcher.js
+++ b/lib/round_fetcher.js
@@ -1,5 +1,6 @@
 const fs = require('fs');
-const request = require('request');
+const { pipeline } = require('stream');
+const needle = require('needle');
 const Promise = require('bluebird');
 
 class RoundFetcher {
@@ -9,17 +10,49 @@ class RoundFetcher {
 
   async fetch() {
     let downloadPromises = this.roundManager.songs.map((song) => {
-      return new Promise((resolve) => {
+      return new Promise((resolve, reject) => {
         let downloadPath = `${this.roundManager.dirs.download}/${song.filename()}`;
         let writeStream = fs.createWriteStream(downloadPath);
-        let requestStream = request(song.url);
-
-        let pipe = requestStream.pipe(writeStream);
-
-        pipe.on('finish', () => {
-          song.paths.download = downloadPath;
-          resolve();
+        let requestStream = needle.get(song.url, {
+          // ._. why snakecase, needle? why?
+          // eslint-disable-next-line camelcase
+          response_timeout: 30000,
+          // eslint-disable-next-line camelcase
+          read_timeout: 30000
         });
+
+        console.info(`FETCH[START]: Downloading ${song.id} to ${downloadPath}`.info);
+
+        // I hate that I have to do this.
+        // I seem to be getting inconsistent emitted errors below, so I want to make sure we only ever report
+        // and reject the promise on the first one.
+        // Next, I should try using node-fetch and see if it is more consistent so we can drop this.
+        let rejected = false;
+        let handleError = (err, msg) => {
+          if (rejected) {
+            return;
+          }
+          console.error(msg.error);
+          reject(err);
+          rejected = true;
+        };
+
+        requestStream.on('timeout', (err) => handleError(err, `FETCH[TIMEOUT]: Downloading ${song.id} from ${song.url} to ${downloadPath}`));
+        requestStream.on('err', (err) => handleError(err, `FETCH[ERROR]: Downloading ${song.id} from ${song.url} to ${downloadPath}`));
+
+        pipeline(
+          requestStream,
+          writeStream,
+          (err) => {
+            if (err) {
+              handleError(err, `FETCH[ERROR]: Downloading ${song.id} from ${song.url} to ${downloadPath}`);
+            } else if (!rejected) {
+              console.info(`FETCH[FINISH]: Downloaded to ${downloadPath}`.success);
+              song.paths.download = downloadPath;
+              resolve();
+            }
+          }
+        );
       });
     });
 

--- a/lib/round_fetcher.js
+++ b/lib/round_fetcher.js
@@ -3,6 +3,7 @@ const stream = require('stream');
 const util = require('util');
 
 const Promise = require('bluebird');
+const Bottleneck = require('bottleneck');
 const needle = require('needle');
 
 const pipeline = util.promisify(stream.pipeline);
@@ -13,8 +14,13 @@ class RoundFetcher {
   }
 
   async fetch() {
+    let limiter = new Bottleneck({
+      maxConcurrent: 3,
+      minTime: 333
+    });
+
     let downloadPromises = this.roundManager.songs.map((song) => {
-      return this.fetchSong(song);
+      return limiter.schedule(() => this.fetchSong(song));
     });
 
     await Promise.all(downloadPromises);

--- a/lib/round_manager.js
+++ b/lib/round_manager.js
@@ -14,7 +14,8 @@ class RoundManager {
       parent: parentDir,
       download: `${parentDir}/download`,
       transcode: `${parentDir}/transcode`,
-      final: `${parentDir}/final`
+      final: `${parentDir}/final`,
+      announcer: `${parentDir}/announcer`
     };
 
     this._makeDirectories();
@@ -41,7 +42,7 @@ class RoundManager {
   }
 
   _makeDirectories() {
-    let dirs = [this.dirs.parent, this.dirs.download, this.dirs.transcode, this.dirs.final];
+    let dirs = [this.dirs.parent, this.dirs.download, this.dirs.transcode, this.dirs.final, this.dirs.announcer];
     dirs.forEach((dir) => {
       this._makeDirectoryIfItDoesntExist(dir);
     });

--- a/lib/round_transcoder.js
+++ b/lib/round_transcoder.js
@@ -3,6 +3,7 @@ const stream = require('stream');
 const util = require('util');
 
 const Promise = require('bluebird');
+const Bottleneck = require('bottleneck');
 const lame = require('lame');
 const mm = require('music-metadata');
 const soxCallback = require('sox.js');
@@ -16,8 +17,12 @@ class RoundTranscoder {
   }
 
   async transcode() {
+    let limiter = new Bottleneck({
+      maxConcurrent: 3
+    });
+
     let transcoderPromises = this.roundManager.songs.map((song) => {
-      return this.transcodeSong(song);
+      return limiter.schedule(() => this.transcodeSong(song));
     });
 
     await Promise.all(transcoderPromises);

--- a/lib/round_transcoder.js
+++ b/lib/round_transcoder.js
@@ -2,6 +2,7 @@ const fs = require('fs');
 const Promise = require('bluebird');
 const lame = require('lame');
 const mm = require('music-metadata');
+const sox = require('sox.js');
 
 class RoundTranscoder {
   constructor(roundManager) {
@@ -27,31 +28,62 @@ class RoundTranscoder {
     // eslint-disable-next-line require-atomic-updates
     song.metadata = metadata;
 
-    let transcodePromise = new Promise((resolve) => {
+    let transcodePromise = new Promise((resolve, reject) => {
+      let pcmPath = `${this.roundManager.dirs.transcode}/${song.filename({ type: 'transcode-pcm' })}`;
       let transcodePath = `${this.roundManager.dirs.transcode}/${song.filename()}`;
       let finalPath = `${this.roundManager.dirs.final}/${song.filename()}`;
 
-      let readStream = fs.createReadStream(song.paths.download);
-      let decodeStream = new lame.Decoder();
-      let encodeStream = new lame.Encoder({
-        // input
-        channels: metadata.format.numberOfChannels,
-        bitDepth: 16,
-        sampleRate: metadata.format.sampleRate,
+      sox({
+        inputFile: song.paths.download,
+        input: {
+          type: 'mp3'
+        },
+        outputFile: pcmPath,
+        output: {
+          bits: 16,
+          channels: 2,
+          rate: 44100,
+          type: 'raw'
+        }
+      }, (err) => {
+        // If we get an error back from running sox (and it isn't just a warning)
+        // then reject the promise.
+        if (err && !err.message.startsWith('sox WARN')) {
+          reject(err);
+          return;
+        }
 
-        // output
-        bitRate: 320,
-        outSampleRate: 44100,
-        mode: lame.JOINTSTEREO
-      });
-      let writeStream = fs.createWriteStream(transcodePath);
+        let readStream = fs.createReadStream(pcmPath);
+        let encodeStream = new lame.Encoder({
+          // input
+          bitDepth: 16,
+          channels: 2,
+          sampleRate: 44100,
 
-      let pipe = readStream.pipe(decodeStream).pipe(encodeStream).pipe(writeStream);
+          // output
+          bitRate: 320,
+          outSampleRate: 44100,
+          mode: lame.JOINTSTEREO
+        });
+        let writeStream = fs.createWriteStream(transcodePath);
 
-      pipe.on('finish', () => {
-        fs.rename(transcodePath, finalPath, () => {
-          song.paths.final = finalPath;
-          resolve();
+        let pipe = readStream.pipe(encodeStream).pipe(writeStream);
+
+        pipe.on('finish', () => {
+          fs.rename(transcodePath, finalPath, (err) => {
+            if (err) {
+              reject(err);
+            }
+
+            fs.unlink(pcmPath, (err) =>  {
+              if (err) {
+                reject(err);
+              }
+
+              song.paths.final = finalPath;
+              resolve();
+            });
+          });
         });
       });
     });

--- a/lib/round_transcoder.js
+++ b/lib/round_transcoder.js
@@ -1,8 +1,14 @@
 const fs = require('fs');
+const stream = require('stream');
+const util = require('util');
+
 const Promise = require('bluebird');
 const lame = require('lame');
 const mm = require('music-metadata');
-const sox = require('sox.js');
+const soxCallback = require('sox.js');
+
+const pipeline = util.promisify(stream.pipeline);
+const sox = util.promisify(soxCallback);
 
 class RoundTranscoder {
   constructor(roundManager) {
@@ -28,67 +34,61 @@ class RoundTranscoder {
     // eslint-disable-next-line require-atomic-updates
     song.metadata = metadata;
 
-    let transcodePromise = new Promise((resolve, reject) => {
-      let pcmPath = `${this.roundManager.dirs.transcode}/${song.filename({ type: 'transcode-pcm' })}`;
-      let transcodePath = `${this.roundManager.dirs.transcode}/${song.filename()}`;
-      let finalPath = `${this.roundManager.dirs.final}/${song.filename()}`;
+    let pcmPath = `${this.roundManager.dirs.transcode}/${song.filename({ type: 'transcode-pcm' })}`;
+    let transcodePath = `${this.roundManager.dirs.transcode}/${song.filename()}`;
+    let finalPath = `${this.roundManager.dirs.final}/${song.filename()}`;
+    let soxParams = {
+      inputFile: song.paths.download,
+      input: {
+        type: 'mp3'
+      },
+      outputFile: pcmPath,
+      output: {
+        bits: 16,
+        channels: 2,
+        rate: 44100,
+        type: 'raw'
+      }
+    };
 
-      sox({
-        inputFile: song.paths.download,
-        input: {
-          type: 'mp3'
-        },
-        outputFile: pcmPath,
-        output: {
-          bits: 16,
-          channels: 2,
-          rate: 44100,
-          type: 'raw'
+    await sox(soxParams).catch((err) => {
+      // If we get an error back from running sox (and it isn't just a warning)
+      // then throw an error.
+      if (err && !err.message.startsWith('sox WARN')) {
+        if (err instanceof Error) {
+          throw err;
+        } else {
+          // If it's not an error instance, assume it is a string we should wrap with an Error
+          throw new Error(err);
         }
-      }, (err) => {
-        // If we get an error back from running sox (and it isn't just a warning)
-        // then reject the promise.
-        if (err && !err.message.startsWith('sox WARN')) {
-          reject(err);
-          return;
-        }
-
-        let readStream = fs.createReadStream(pcmPath);
-        let encodeStream = new lame.Encoder({
-          // input
-          bitDepth: 16,
-          channels: 2,
-          sampleRate: 44100,
-
-          // output
-          bitRate: 320,
-          outSampleRate: 44100,
-          mode: lame.JOINTSTEREO
-        });
-        let writeStream = fs.createWriteStream(transcodePath);
-
-        let pipe = readStream.pipe(encodeStream).pipe(writeStream);
-
-        pipe.on('finish', () => {
-          fs.rename(transcodePath, finalPath, (err) => {
-            if (err) {
-              reject(err);
-            }
-
-            fs.unlink(pcmPath, (err) =>  {
-              if (err) {
-                reject(err);
-              }
-
-              song.paths.final = finalPath;
-              resolve();
-            });
-          });
-        });
-      });
+      }
     });
 
-    await transcodePromise;
+    let readStream = fs.createReadStream(pcmPath);
+    let encodeStream = new lame.Encoder({
+      // input
+      bitDepth: 16,
+      channels: 2,
+      sampleRate: 44100,
+
+      // output
+      bitRate: 320,
+      outSampleRate: 44100,
+      mode: lame.JOINTSTEREO
+    });
+    let writeStream = fs.createWriteStream(transcodePath);
+
+    await pipeline(
+      readStream,
+      encodeStream,
+      writeStream
+    );
+
+    await fs.promises.rename(transcodePath, finalPath);
+    await fs.promises.unlink(pcmPath);
+
+    // eslint-disable-next-line require-atomic-updates
+    song.paths.final = finalPath;
   }
 }
 

--- a/lib/song.js
+++ b/lib/song.js
@@ -9,12 +9,22 @@ class Song {
     this.paths = {
       download: null,
       transcode: null,
-      final: null
+      final: null,
+      announcer: null
     };
   }
 
-  filename() {
-    return `${this.id}.mp3`;
+  filename({ type } = { type: 'final' }) {
+    switch (type) {
+      case 'transcode-pcm':
+        return `${this.id}.pcm`;
+      case 'announcer-aws':
+        return `${this.id}-aws.mp3`;
+      case 'announcer-pcm':
+        return `${this.id}-aws.pcm`;
+      default:
+        return `${this.id}.mp3`;
+    }
   }
 }
 

--- a/lib/stream_manager.js
+++ b/lib/stream_manager.js
@@ -39,10 +39,10 @@ class StreamManager extends EventEmitter {
     this._shout.setPassword(fetchEnv('HUBOT_STREAM_SOURCE_PASSWORD'));
     this._shout.setMount(this.mount);
     this._shout.setFormat(1); // 0=ogg, 1=mp3
-    // this._shout.setAudioInfo('bitrate', '192');
-    // this._shout.setAudioInfo('samplerate', '44100');
-    // this._shout.setAudioInfo('channels', '2');
-    // this._shout.open();
+    this._shout.setName(`${this.roundId} Listening Party`);
+    this._shout.setAudioInfo('bitrate', '320');
+    this._shout.setAudioInfo('samplerate', '44100');
+    this._shout.setAudioInfo('channels', '2');
 
     this.emit('compoMetadataFetching');
     await this.roundManager.getAllSongs();

--- a/lib/stream_manager.js
+++ b/lib/stream_manager.js
@@ -121,6 +121,10 @@ class StreamManager extends EventEmitter {
   }
 
   _stopCurrentSong() {
+    // If we don't have any song loaded, there's nothing to stop!
+    if (!this.fileStream) {
+      return;
+    }
     this.fileStream.unpipe(this.shoutStream);
     this.shoutStream.end();
   }

--- a/lib/stream_manager.js
+++ b/lib/stream_manager.js
@@ -1,6 +1,7 @@
 const EventEmitter = require('events');
 const nodeshout = require('nodeshout');
 const Promise = require('bluebird');
+const RoundAnnouncer = require('../lib/round_announcer');
 const RoundFetcher = require('../lib/round_fetcher');
 const RoundManager = require('../lib/round_manager');
 const RoundTranscoder = require('../lib/round_transcoder');
@@ -23,6 +24,7 @@ class StreamManager extends EventEmitter {
     this.roundManager = new RoundManager(roundId);
     this.roundFetcher = new RoundFetcher(this.roundManager);
     this.roundTranscoder = new RoundTranscoder(this.roundManager);
+    this.roundAnnouncer = new RoundAnnouncer(this.roundManager);
     this.stopped = false;
   }
 
@@ -51,6 +53,9 @@ class StreamManager extends EventEmitter {
     this.emit('transcodingSongs');
     await this.roundTranscoder.transcode();
 
+    this.emit('generatingAnnouncer');
+    await this.roundAnnouncer.process();
+
     this.emit('startingStream');
     this._shout.open();
 
@@ -72,7 +77,7 @@ class StreamManager extends EventEmitter {
   }
 
   async playIntro() {
-    this.fileStream = fs.createReadStream('./music/intro.mp3');
+    this.fileStream = fs.createReadStream('./music/intro.mp3', { highWaterMark: 65536 });
     this.shoutStream = new ShoutStream(this._shout);
     let songStream = this.fileStream.pipe(this.shoutStream);
 
@@ -86,15 +91,22 @@ class StreamManager extends EventEmitter {
   }
 
   async playSong(song) {
-    this.fileStream = fs.createReadStream(song.paths.final);
+    this.fileStream = fs.createReadStream(song.paths.announcer, { highWaterMark: 65536 });
     this.shoutStream = new ShoutStream(this._shout);
-    let songStream = this.fileStream.pipe(this.shoutStream);
 
     this.emit('playing', song);
 
-    return new Promise(function(resolve) {
-      songStream.on('finish', function() {
-        resolve();
+    return new Promise((resolve) => {
+      let announcerStream = this.fileStream.pipe(this.shoutStream);
+      announcerStream.on('finish', () => {
+        this.fileStream = fs.createReadStream(song.paths.final, { highWaterMark: 65536 });
+        this.shoutStream = new ShoutStream(this._shout);
+
+        let songStream = this.fileStream.pipe(this.shoutStream);
+
+        songStream.on('finish', () => {
+          resolve();
+        });
       });
     });
   }

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "aws-sdk": "^2.538.0",
     "bluebird": "^3.5.5",
     "cheerio": "^0.22.0",
+    "colors": "^1.4.0",
     "hubot": "^3.3.2",
     "hubot-diagnostics": "1.0.0",
     "hubot-discord": "thetimpanist/hubot-discord#master",
@@ -23,9 +24,9 @@
     "hubot-shipit": "^0.2.1",
     "lame": "fusion2004/node-lame#master",
     "music-metadata": "^4.8.0",
+    "needle": "^2.5.0",
     "node-fetch": "^2.6.0",
     "nodeshout": "^0.1.3",
-    "request": "^2.88.0",
     "sox.js": "^2.1.0",
     "streamifier": "^0.1.1"
   },

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "author": "Mark Oleson <fusion2004@gmail.com>",
   "description": "A simple helpful robot",
   "dependencies": {
+    "aws-sdk": "^2.538.0",
     "bluebird": "^3.5.5",
     "cheerio": "^0.22.0",
     "hubot": "^3.3.2",
@@ -20,11 +21,13 @@
     "hubot-rules": "^1.0.0",
     "hubot-scripts": "^2.17.2",
     "hubot-shipit": "^0.2.1",
-    "lame": "^1.2.4",
+    "lame": "fusion2004/node-lame#master",
     "music-metadata": "^4.8.0",
     "node-fetch": "^2.6.0",
     "nodeshout": "^0.1.3",
-    "request": "^2.88.0"
+    "request": "^2.88.0",
+    "sox.js": "^2.1.0",
+    "streamifier": "^0.1.1"
   },
   "engines": {
     "node": "10"

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "dependencies": {
     "aws-sdk": "^2.538.0",
     "bluebird": "^3.5.5",
+    "bottleneck": "^2.19.5",
     "cheerio": "^0.22.0",
     "colors": "^1.4.0",
     "hubot": "^3.3.2",

--- a/scripts/stream.js
+++ b/scripts/stream.js
@@ -67,6 +67,9 @@ module.exports = function(robot) {
     currentStream.on('transcodingSongs', function() {
       res.send(`*Transcoding ${round} songs for streaming...*`);
     });
+    currentStream.on('generatingAnnouncer', function() {
+      res.send('*Clearing throat, performing vocal exercises...*');
+    });
 
     currentStream.on('finish', function() {
       discord.user.setActivity('nothing...');

--- a/scripts/stream.js
+++ b/scripts/stream.js
@@ -20,6 +20,17 @@
 //   <github username of the original script author>
 
 const StreamManager = require('../lib/stream_manager');
+const colors = require('colors');
+
+// importing colors extends the String prototype so we can call these directly
+// on strings: 'something went wrong'.error
+colors.setTheme({
+  info: 'blue',
+  help: 'cyan',
+  warn: 'yellow',
+  success: 'green',
+  error: 'red'
+});
 
 function lastAccessed(brain) {
   let data = brain.get('lastAccessed');

--- a/yarn.lock
+++ b/yarn.lock
@@ -323,6 +323,11 @@ color-name@1.1.3:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
   integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
 
+colors@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
+  integrity sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==
+
 combined-stream@^1.0.6, combined-stream@~1.0.6:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
@@ -420,6 +425,13 @@ debug@2, debug@2.6.9, debug@^2.2.0:
   integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
   dependencies:
     ms "2.0.0"
+
+debug@^3.2.6:
+  version "3.2.6"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
+  integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
+  dependencies:
+    ms "^2.1.1"
 
 debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
   version "4.1.1"
@@ -1064,7 +1076,7 @@ hubot@^3.3.2:
     optparse "1.0.4"
     scoped-http-client "0.11.0"
 
-iconv-lite@0.4.24, iconv-lite@^0.4.24:
+iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@^0.4.4:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
@@ -1441,6 +1453,15 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
 
+needle@^2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/needle/-/needle-2.5.0.tgz#e6fc4b3cc6c25caed7554bd613a5cf0bac8c31c0"
+  integrity sha512-o/qITSDR0JCyCKEQ1/1bnUXMmznxabbwi/Y4WwJElf+evwJNFNwIDMCCt5IigFVxgeGBJESLohGtIS9gEzo1fA==
+  dependencies:
+    debug "^3.2.6"
+    iconv-lite "^0.4.4"
+    sax "^1.2.4"
+
 negotiator@0.6.2:
   version "0.6.2"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.2.tgz#feacf7ccf525a77ae9634436a64883ffeca346fb"
@@ -1725,7 +1746,7 @@ regexpp@^2.0.1:
   resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-2.0.1.tgz#8d19d31cf632482b589049f8281f93dbcba4d07f"
   integrity sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==
 
-request@^2.79.0, request@^2.88.0:
+request@^2.79.0:
   version "2.88.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.88.0.tgz#9c2fca4f7d35b592efe57c7f0a55e81052124fef"
   integrity sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==
@@ -1805,7 +1826,7 @@ sax@1.2.1:
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.1.tgz#7b8e656190b228e81a66aea748480d828cd2d37a"
   integrity sha1-e45lYZCyKOgaZq6nSEgNgozS03o=
 
-sax@>=0.6.0:
+sax@>=0.6.0, sax@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -210,6 +210,11 @@ boolbase@~1.0.0:
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
   integrity sha1-aN/1++YMUes3cl6p4+0xDcwed24=
 
+bottleneck@^2.19.5:
+  version "2.19.5"
+  resolved "https://registry.yarnpkg.com/bottleneck/-/bottleneck-2.19.5.tgz#5df0b90f59fd47656ebe63c78a98419205cadd91"
+  integrity sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==
+
 brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"

--- a/yarn.lock
+++ b/yarn.lock
@@ -130,6 +130,21 @@ asynckit@^0.4.0:
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
   integrity sha1-x57Zf380y48robyXkLzDZkdLS3k=
 
+aws-sdk@^2.538.0:
+  version "2.538.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.538.0.tgz#c2a6b482c191615457993d9cfb28a79d0847bb71"
+  integrity sha512-mQTo1eWoU8UB2Pp1PyBBSrFKfaFIVNKeLjJslrhHV5eW/orv2Lw07shnbY4cSt+n2oumw45WStWORyLekRvjyA==
+  dependencies:
+    buffer "4.9.1"
+    events "1.1.1"
+    ieee754 "1.1.13"
+    jmespath "0.15.0"
+    querystring "0.2.0"
+    sax "1.2.1"
+    url "0.10.3"
+    uuid "3.3.2"
+    xml2js "0.4.19"
+
 aws-sign2@~0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.7.0.tgz#b46e890934a9591f2d2f6f86d7e6a9f1b3fe76a8"
@@ -144,6 +159,11 @@ balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
   integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
+
+base64-js@^1.0.2:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.3.1.tgz#58ece8cb75dd07e71ed08c736abc5fac4dbf8df1"
+  integrity sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==
 
 bcrypt-pbkdf@^1.0.0:
   version "1.0.2"
@@ -197,6 +217,15 @@ brace-expansion@^1.1.7:
   dependencies:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
+
+buffer@4.9.1:
+  version "4.9.1"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-4.9.1.tgz#6d1bb601b07a4efced97094132093027c95bc298"
+  integrity sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=
+  dependencies:
+    base64-js "^1.0.2"
+    ieee754 "^1.1.4"
+    isarray "^1.0.0"
 
 bytes@3.1.0:
   version "3.1.0"
@@ -666,6 +695,11 @@ etag@~1.8.1:
   resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
   integrity sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=
 
+events@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/events/-/events-1.1.1.tgz#9ebdb7635ad099c70dcc4c2a1f5004288e8bd924"
+  integrity sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=
+
 express@^4.16.3:
   version "4.17.1"
   resolved "https://registry.yarnpkg.com/express/-/express-4.17.1.tgz#4491fc38605cf51f8629d39c2b5d026f98a4c134"
@@ -900,6 +934,11 @@ has-flag@^3.0.0:
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
   integrity sha1-tdRU3CGZriJWmfNGfloH87lVuv0=
 
+hash-to-array@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/hash-to-array/-/hash-to-array-1.0.1.tgz#2b0e284c04a32c34580248a332b962eb155e0f6f"
+  integrity sha1-Kw4oTASjLDRYAkijMrli6xVeD28=
+
 htmlparser2@^3.9.1:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-3.10.1.tgz#bd679dc3f59897b6a34bb10749c855bb53a9392f"
@@ -1032,6 +1071,11 @@ iconv-lite@0.4.24, iconv-lite@^0.4.24:
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
+ieee754@1.1.13, ieee754@^1.1.4:
+  version "1.1.13"
+  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.13.tgz#ec168558e95aa181fd87d37f55c32bbcb6708b84"
+  integrity sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==
+
 ignore@^4.0.6:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
@@ -1124,6 +1168,11 @@ isarray@0.0.1:
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
   integrity sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=
 
+isarray@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
+  integrity sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=
+
 isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
@@ -1133,6 +1182,11 @@ isstream@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
   integrity sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=
+
+jmespath@0.15.0:
+  version "0.15.0"
+  resolved "https://registry.yarnpkg.com/jmespath/-/jmespath-0.15.0.tgz#a3f222a9aae9f966f5d27c796510e28091764217"
+  integrity sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc=
 
 js-tokens@^4.0.0:
   version "4.0.0"
@@ -1182,10 +1236,9 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.10.0"
 
-lame@^1.2.4:
+lame@fusion2004/node-lame#master:
   version "1.2.4"
-  resolved "https://registry.yarnpkg.com/lame/-/lame-1.2.4.tgz#546801514e2de8ca0c89eef222880c8dc6712485"
-  integrity sha1-VGgBUU4t6MoMie7yIogMjcZxJIU=
+  resolved "https://codeload.github.com/fusion2004/node-lame/tar.gz/e5a8c13b5d7f864a1d1da367f9da3862dd3453ad"
   dependencies:
     bindings "^1.2.1"
     debug "^2.2.0"
@@ -1444,6 +1497,11 @@ once@^1.3.0:
   dependencies:
     wrappy "1"
 
+onetime@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/onetime/-/onetime-1.1.0.tgz#a1f7838f8314c516f05ecefcbc4ccfe04b4ed789"
+  integrity sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=
+
 onetime@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/onetime/-/onetime-2.0.1.tgz#067428230fd67443b2794b22bba528b6867962d4"
@@ -1543,6 +1601,11 @@ psl@^1.1.24:
   resolved "https://registry.yarnpkg.com/psl/-/psl-1.4.0.tgz#5dd26156cdb69fa1fdb8ab1991667d3f80ced7c2"
   integrity sha512-HZzqCGPecFLyoRj5HLfuDSKYTJkAfB5thKBIkRHtGjWwY7p1dAyveIbXIq4tO0KYfDF2tHqPUgY9SDnGm00uFw==
 
+punycode@1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.3.2.tgz#9653a036fb7c1ee42342f2325cceefea3926c48d"
+  integrity sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=
+
 punycode@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
@@ -1562,6 +1625,11 @@ qs@~6.5.2:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
   integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
+
+querystring@0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
+  integrity sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=
 
 random-bytes@~1.0.0:
   version "1.0.0"
@@ -1732,6 +1800,16 @@ safe-buffer@^5.0.1, safe-buffer@^5.1.2, safe-buffer@~5.2.0:
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
+sax@1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.1.tgz#7b8e656190b228e81a66aea748480d828cd2d37a"
+  integrity sha1-e45lYZCyKOgaZq6nSEgNgozS03o=
+
+sax@>=0.6.0:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
+  integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
+
 scoped-http-client@0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/scoped-http-client/-/scoped-http-client-0.11.0.tgz#887fa82a8360f15d639a52e504e563c157d26d74"
@@ -1812,6 +1890,14 @@ snekfetch@^3.6.4:
   resolved "https://registry.yarnpkg.com/snekfetch/-/snekfetch-3.6.4.tgz#d13e80a616d892f3d38daae4289f4d258a645120"
   integrity sha512-NjxjITIj04Ffqid5lqr7XdgwM7X61c/Dns073Ly170bPQHLm6jkmelye/eglS++1nfTWktpP6Y2bFXjdPlQqdw==
 
+sox.js@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/sox.js/-/sox.js-2.1.0.tgz#9bab6381cd0b1f4ab806e460204c0d8fea2e5f87"
+  integrity sha512-KAr3opM5ywyOyV+0V1qxf537s/bxe0dT+gpbHEWfhay9pWvf9uaJsUEhTxRyKj/OPfnMayac7/ZrFR1GIZF4uQ==
+  dependencies:
+    hash-to-array "^1.0.0"
+    onetime "^1.0.0"
+
 sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
@@ -1836,6 +1922,11 @@ sshpk@^1.7.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
   integrity sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=
+
+streamifier@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/streamifier/-/streamifier-0.1.1.tgz#97e98d8fa4d105d62a2691d1dc07e820db8dfc4f"
+  integrity sha1-l+mNj6TRBdYqJpHR3AfoINuN/E8=
 
 string-width@^2.1.0:
   version "2.1.1"
@@ -2024,6 +2115,14 @@ uri-js@^4.2.2:
   dependencies:
     punycode "^2.1.0"
 
+url@0.10.3:
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/url/-/url-0.10.3.tgz#021e4d9c7705f21bbf37d03ceb58767402774c64"
+  integrity sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=
+  dependencies:
+    punycode "1.3.2"
+    querystring "0.2.0"
+
 util-deprecate@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
@@ -2033,6 +2132,11 @@ utils-merge@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=
+
+uuid@3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
+  integrity sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==
 
 uuid@^3.3.2:
   version "3.3.3"
@@ -2088,3 +2192,16 @@ ws@^6.0.0:
   integrity sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==
   dependencies:
     async-limiter "~1.0.0"
+
+xml2js@0.4.19:
+  version "0.4.19"
+  resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.4.19.tgz#686c20f213209e94abf0d1bcf1efaa291c7827a7"
+  integrity sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==
+  dependencies:
+    sax ">=0.6.0"
+    xmlbuilder "~9.0.1"
+
+xmlbuilder@~9.0.1:
+  version "9.0.7"
+  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-9.0.7.tgz#132ee63d2ec5565c557e20f4c22df9aca686b10d"
+  integrity sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=


### PR DESCRIPTION
This introduces programmatic announcer tracks, played before each song in the round.

It also fixes some bugs with transcoding & downloading by switching out node-lame for my version with a weird buffer fix, using sox for an intermediate pcm transcode step, and limiting the concurrency of those actions.

It also also cleans up the code using `streams.pipeline` and `util.promisify` to really flatten the async functions.