### PR TITLE
Refetching rounds

### DIFF
--- a/VENDOR_INSTALL.md
+++ b/VENDOR_INSTALL.md
@@ -1,6 +1,6 @@
 # Compiling and installing vendor libraries
 
-```
+```shell
 docker run -it --name thasauce-build heroku/heroku:18-build bash
 
 mkdir /app

--- a/commands/compoverse/playlist.js
+++ b/commands/compoverse/playlist.js
@@ -1,0 +1,40 @@
+const { Command } = require('discord.js-commando');
+
+const { store } = require('../../lib/chorus-store');
+
+module.exports = class PlaylistCommand extends Command {
+  constructor(client) {
+    super(client, {
+      name: 'playlist',
+      aliases: [],
+      group: 'compoverse',
+      memberName: 'playlist',
+      description: 'Lists all songs in the listening party, highlighting where we are',
+      guildOnly: true
+    });
+  }
+
+  async run(message) {
+    let currentStream = store.state.context.stream.manager;
+    if (!currentStream || currentStream.stopped) {
+      message.reply('there is no listening party, currently!');
+      return;
+    }
+
+    let { currentSong, songs } = currentStream.roundManager;
+
+    let msg = '';
+    songs.forEach((song, index) => {
+      if (currentSong && currentSong.id === song.id) {
+        msg = msg.concat('**');
+      }
+      msg = msg.concat(`${index + 1}. ${song.title}`);
+      if (currentSong && currentSong.id === song.id) {
+        msg = msg.concat('**');
+      }
+      msg = msg.concat('\n');
+    });
+
+    message.say(msg);
+  }
+};

--- a/commands/compoverse/refetchparty.js
+++ b/commands/compoverse/refetchparty.js
@@ -1,0 +1,27 @@
+const { Command } = require('discord.js-commando');
+
+const { store } = require('../../lib/chorus-store');
+
+module.exports = class RefetchPartyCommand extends Command {
+  constructor(client) {
+    super(client, {
+      name: 'refetchparty',
+      aliases: ['refetch'],
+      group: 'compoverse',
+      memberName: 'refetchparty',
+      description: 'Refetches the round for the current listening party (to load new entries)',
+      guildOnly: true
+    });
+  }
+
+  async run(message) {
+    let currentStream = store.state.context.stream.manager;
+    if (!currentStream || currentStream.stopped) {
+      message.reply('there is no listening party, currently!');
+      return;
+    }
+
+    await currentStream.refetch();
+    message.reply(`${currentStream.roundId} refetched!`);
+  }
+};

--- a/commands/compoverse/skipsong.js
+++ b/commands/compoverse/skipsong.js
@@ -2,7 +2,7 @@ const { Command } = require('discord.js-commando');
 
 const { store } = require('../../lib/chorus-store');
 
-module.exports = class StartPartyCommand extends Command {
+module.exports = class SkipSongCommand extends Command {
   constructor(client) {
     super(client, {
       name: 'skipsong',

--- a/commands/compoverse/startparty.js
+++ b/commands/compoverse/startparty.js
@@ -48,8 +48,9 @@ module.exports = class StartPartyCommand extends Command {
     streamManager.on('playing', function(song) {
       const embed = new RichEmbed()
         .setColor('#39aa6e')
-        .setTitle(`:smile: Now playing: ${song.title}`)
-        .setAuthor(song.artist)
+        .setTitle(song.title)
+        .setAuthor('now playing')
+        .addField('Artist', song.artist)
         .addField('Length', formatDuration(song.metadata.format.duration));
 
       message.embed(embed);

--- a/commands/compoverse/startparty.js
+++ b/commands/compoverse/startparty.js
@@ -78,6 +78,8 @@ module.exports = class StartPartyCommand extends Command {
     });
 
     this.client.user.setActivity(`in #${message.channel.name}`);
-    streamManager.start();
+    await streamManager.start().catch((error) => {
+      throw error;
+    });
   }
 };

--- a/commands/compoverse/stopparty.js
+++ b/commands/compoverse/stopparty.js
@@ -2,7 +2,7 @@ const { Command } = require('discord.js-commando');
 
 const { store } = require('../../lib/chorus-store');
 
-module.exports = class StartPartyCommand extends Command {
+module.exports = class StopPartyCommand extends Command {
   constructor(client) {
     super(client, {
       name: 'stopparty',

--- a/index.js
+++ b/index.js
@@ -1,6 +1,8 @@
 const path = require('path');
 const colors = require('colors');
 const { CommandoClient } = require('discord.js-commando');
+// const KeyvProvider = require('commando-provider-keyv');
+// const Keyv = require('keyv');
 
 const fetchEnv = require('./utils/fetch-env');
 const { roleIds, memberHasOneOfTheseRoles } = require('./utils/roles');
@@ -20,6 +22,9 @@ let client = new CommandoClient({
   owner: '92330214046072832'
 });
 
+// If we need to store settings or data in redis, here's how to set that up.
+// client.setProvider(new KeyvProvider(new Keyv(fetchEnv('REDIS_URL'))));
+
 client.registry
   .registerDefaultTypes()
   .registerGroups([
@@ -35,6 +40,11 @@ client.once('ready', () => {
 });
 
 client.on('error', console.error);
+
+// maybeh?
+// process.on('unhandledRejection', err => {
+//   console.warn(`Uncaught Promise Error: \n${err.stack}`)
+// });
 
 client.dispatcher.addInhibitor((message) => {
   if (!message.command || !message.command.group) {

--- a/index.js
+++ b/index.js
@@ -41,6 +41,11 @@ client.once('ready', () => {
 
 client.on('error', console.error);
 
+client.on('commandError', (command, error) => {
+  console.error(`Error running command: ${command.name}`);
+  console.error(error);
+});
+
 // maybeh?
 // process.on('unhandledRejection', err => {
 //   console.warn(`Uncaught Promise Error: \n${err.stack}`)

--- a/lib/compo_thasauce_fetcher.js
+++ b/lib/compo_thasauce_fetcher.js
@@ -5,8 +5,9 @@ const Song = require('./song.js');
 const ROOT_URL = 'http://compo.thasauce.net';
 
 class CompoThaSauceFetcher {
-  constructor(roundId) {
+  constructor(roundId, parentDir) {
     this.roundId = roundId;
+    this.parentDir = parentDir;
   }
 
   url() {
@@ -24,16 +25,19 @@ class CompoThaSauceFetcher {
     let $ = cheerio.load(body);
     let items = $('#round-entries .item');
 
-    let songs = items.toArray().map(function(item) {
+    let songs = items.toArray().map((item) => {
       let $item = $(item);
       let songDownloadAnchor = $item.find('.song-download');
 
-      return new Song({
-        id: $item.data('id'),
+      let song = new Song(this.parentDir);
+      let event = {
+        songId: $item.data('id'),
         title: $item.data('title'),
         artist: $item.data('author'),
         url: ROOT_URL + songDownloadAnchor.attr('href')
-      });
+      };
+      song.service.send('FETCH_FINISH', event);
+      return song;
     });
 
     return songs;

--- a/lib/machines.js
+++ b/lib/machines.js
@@ -1,0 +1,69 @@
+const { createMachine } = require('xstate');
+const { assign, createUpdater } = require('@xstate/immer');
+
+let metadataUpdater = createUpdater('UPDATE_METADATA', (context, { input }) => context.metadata = input);
+
+let songMachine = createMachine({
+  initial: 'init',
+  context: {},
+  states: {
+    init: {
+      on: {
+        FETCH_FINISH: {
+          target: 'fetched',
+          actions: ['storeFetchedData']
+        }
+      }
+    },
+    fetched: {
+      on: {
+        START_DOWNLOAD: 'downloading',
+        SKIP_DOWNLOAD: 'downloaded',
+        SKIP_TRANSCODE: 'transcoded'
+      }
+    },
+    downloading: {
+      on: {
+        FINISH_DOWNLOAD: 'downloaded'
+      }
+    },
+    downloaded: {
+      on: {
+        START_TRANSCODE: 'transcoding'
+      }
+    },
+    transcoding: {
+      on: {
+        FINISH_TRANSCODE: {
+          target: 'transcoded'
+        }
+      }
+    },
+    transcoded: {
+      on: {
+        START_ANNOUNCER_DL_AND_TRANSCODE: 'announcerProcessing',
+        [metadataUpdater.type]: { actions: metadataUpdater.action }
+      }
+    },
+    announcerProcessing: {
+      on: {
+        FINISH_ANNOUNCER_DL_AND_TRANSCODE: 'ready'
+      }
+    },
+    ready: {}
+  }
+}, {
+  actions: {
+    storeFetchedData: assign((context, event) => {
+      context.id = event.songId;
+      context.title = event.title;
+      context.artist = event.artist;
+      context.url = event.url;
+    })
+  }
+});
+
+module.exports = {
+  songMachine,
+  metadataUpdater
+};

--- a/lib/round_announcer.js
+++ b/lib/round_announcer.js
@@ -9,6 +9,8 @@ const lame = require('lame');
 const soxCallback = require('sox.js');
 const streamifier = require('streamifier');
 
+const { announcerAws, announcerFinal, announcerIntermediate, announcerPcm } = require('../utils/symbols');
+
 const pipeline = util.promisify(stream.pipeline);
 const sox = util.promisify(soxCallback);
 
@@ -23,7 +25,9 @@ class RoundAnnouncer {
       minTime: 333
     });
 
-    let processPromises = this.roundManager.songs.map((song) => {
+    let songsToProcess = this.roundManager.songs.filter((song) => song.service.state.matches('transcoded'));
+
+    let processPromises = songsToProcess.map((song) => {
       return limiter.schedule(() => this.processSong(song));
     });
 
@@ -32,9 +36,10 @@ class RoundAnnouncer {
 
   async processSong(song) {
     let polly = new AWS.Polly();
-    let awsPath = `${this.roundManager.dirs.announcer}/${song.filename({ type: 'announcer-aws' })}`;
-    let pcmPath = `${this.roundManager.dirs.announcer}/${song.filename({ type: 'announcer-pcm' })}`;
-    let finalPath = `${this.roundManager.dirs.announcer}/${song.filename()}`;
+    let awsPath = song.path(announcerAws);
+    let pcmPath = song.path(announcerPcm);
+    let intermediatePath = song.path(announcerIntermediate);
+    let finalPath = song.path(announcerFinal);
 
     // TODO: use randomization and song position to make this more dynamic
     let text = `Next up: ${song.title} by ${song.artist}`;
@@ -50,6 +55,8 @@ class RoundAnnouncer {
     let response = await polly.synthesizeSpeech(params).promise();
     let pollyReadStream = streamifier.createReadStream(response.AudioStream);
     let pcmWriteStream = fs.createWriteStream(awsPath);
+
+    song.service.send('START_ANNOUNCER_DL_AND_TRANSCODE');
 
     await pipeline(pollyReadStream, pcmWriteStream);
 
@@ -92,7 +99,7 @@ class RoundAnnouncer {
       outSampleRate: 44100,
       mode: lame.JOINTSTEREO
     });
-    let mp3WriteStream = fs.createWriteStream(finalPath);
+    let mp3WriteStream = fs.createWriteStream(intermediatePath);
 
     await pipeline(
       pcmReadStream,
@@ -100,11 +107,11 @@ class RoundAnnouncer {
       mp3WriteStream
     );
 
+    await fs.promises.rename(intermediatePath, finalPath);
     await fs.promises.unlink(awsPath);
     await fs.promises.unlink(pcmPath);
 
-    // eslint-disable-next-line require-atomic-updates
-    song.paths.announcer = finalPath;
+    song.service.send('FINISH_ANNOUNCER_DL_AND_TRANSCODE');
   }
 }
 

--- a/lib/round_fetcher.js
+++ b/lib/round_fetcher.js
@@ -6,6 +6,8 @@ const Promise = require('bluebird');
 const Bottleneck = require('bottleneck');
 const needle = require('needle');
 
+const { downloadFinal, downloadIntermediate } = require('../utils/symbols');
+
 const pipeline = util.promisify(stream.pipeline);
 
 class RoundFetcher {
@@ -19,7 +21,9 @@ class RoundFetcher {
       minTime: 333
     });
 
-    let downloadPromises = this.roundManager.songs.map((song) => {
+    let songsToFetch = this.roundManager.songs.filter((song) => song.service.state.matches('fetched'));
+
+    let downloadPromises = songsToFetch.map((song) => {
       return limiter.schedule(() => this.fetchSong(song));
     });
 
@@ -27,7 +31,8 @@ class RoundFetcher {
   }
 
   async fetchSong(song) {
-    let downloadPath = `${this.roundManager.dirs.download}/${song.filename()}`;
+    let downloadPath = song.path(downloadIntermediate);
+    let finalPath = song.path(downloadFinal);
     let writeStream = fs.createWriteStream(downloadPath);
     let requestStream = needle.get(song.url, {
       // ._. why snakecase, needle? why?
@@ -37,7 +42,7 @@ class RoundFetcher {
       read_timeout: 30000
     });
 
-    console.info(`FETCH[START]: Downloading ${song.id} to ${downloadPath}`.info);
+    song.service.send('START_DOWNLOAD');
 
     // I hate that I have to do this.
     // I seem to be getting inconsistent emitted errors below, so I want to make sure we only ever report
@@ -53,8 +58,6 @@ class RoundFetcher {
       }
     };
 
-    // throw new Error('test fetch error');
-
     requestStream.on('timeout', (err) => handleError(err, `FETCH[TIMEOUT]: Downloading ${song.id} from ${song.url} to ${downloadPath}`));
     requestStream.on('err', (err) => handleError(err, `FETCH[ERROR]: Downloading ${song.id} from ${song.url} to ${downloadPath}`));
 
@@ -62,9 +65,9 @@ class RoundFetcher {
       handleError(err, `FETCH[ERROR]: Downloading ${song.id} from ${song.url} to ${downloadPath}`);
     });
 
-    console.info(`FETCH[FINISH]: Downloaded to ${downloadPath}`.success);
-    // eslint-disable-next-line require-atomic-updates
-    song.paths.download = downloadPath;
+    await fs.promises.rename(downloadPath, finalPath);
+
+    song.service.send('FINISH_DOWNLOAD');
   }
 }
 

--- a/lib/round_manager.js
+++ b/lib/round_manager.js
@@ -1,6 +1,10 @@
 const fs = require('fs');
 const path = require('path');
-const CompoThaSauceFetcher = require('../lib/compo_thasauce_fetcher');
+const mm = require('music-metadata');
+
+const CompoThaSauceFetcher = require('./compo_thasauce_fetcher');
+const { metadataUpdater } = require('./machines');
+const { transcodeFinal } = require('../utils/symbols');
 
 class RoundManager {
   constructor(roundId) {
@@ -38,6 +42,19 @@ class RoundManager {
 
     let songs = await this.fetcher.fetch();
     this.songs = songs;
+  }
+
+  async transitionProcessedSongs() {
+    await Promise.all(this.songs.map((song) => song.transitionIfProcessed()));
+  }
+
+  async parseMetadata() {
+    let promises = this.songs.map(async(song) => {
+      let metadata = await mm.parseFile(song.path(transcodeFinal));
+      song.service.send(metadataUpdater.update(metadata));
+    });
+
+    await Promise.all(promises);
   }
 
   _makeDirectories() {

--- a/lib/round_manager.js
+++ b/lib/round_manager.js
@@ -11,11 +11,22 @@ function songExistsInArray(song, array) {
   return array.some((item) => song.id === item.id);
 }
 
+/**
+ * Reconciles the existing songs with newly fetched songs, leaving in place any
+ * existing songs that still exist, so we maintain those songs' state machines
+ * and processing.
+ *
+ * @param {Array} existingSongs - An array of existing songs
+ * @param {Array} newSongs - An array of newly fetched songs
+ * @returns {Array}
+ */
 function reconcileSongs(existingSongs, newSongs) {
   let left = zippa.ArrayZipper.from(existingSongs).next();
   let right = zippa.ArrayZipper.from(newSongs).next();
 
   while (!left.isEnd() || !right.isEnd()) {
+    // If we reached the end of existing songs, but not the new songs, we want
+    // to append the new song to the existing song.
     if (left.isEnd()) {
       // There doesn't seem to be a way to recover from reaching the END of a
       // zippa, so we'll construct the changes and make a new one!
@@ -26,24 +37,34 @@ function reconcileSongs(existingSongs, newSongs) {
         // We'll go into the array, all the way over to the right, and insert
         // our new entry.
         left = left.down().rightmost().insertRight(right.value());
-        // Finally, we'll get the zippa back to the END. (By going right once, to
-        // get to the newly inserted value, and then again to reach the END.)
-        left = left.next().next();
       } else {
         // Otherwise, we'll make a new zippa using an array of the new entry.
         left = zippa.ArrayZipper.from([right.value()]);
-        // And reach the END again (right once for the value, right again for end)
-        left = left.next().next();
       }
+      // Finally, we'll get the zippa back to the END. (By going right once, to
+      // get to the newly inserted value, and then again to reach the END.)
+      left = left.next().next();
       right = right.next();
+
+    // If we reached the end of the new songs, but not the existing songs, it
+    // means there are extra songs in the existing songs that don't exist
+    // anymore. Thus, we'll remove the current existing song.
     } else if (right.isEnd()) {
       left = left.remove().next();
+
+    // If we're looking at the same song in both, do nothing!
     } else if (left.item.id === right.item.id) {
       left = left.next();
       right = right.next();
+
+    // If the current existing song occurs later in the new songs, we should
+    // insert the current new song to the left of the current existing song.
     } else if (songExistsInArray(left.value(), right.path.right)) {
       left = left.insertLeft(right.value());
       right = right.next();
+
+    // Otherwise, the current existing song no longer exists, so we should
+    // remove it.
     } else {
       left = left.remove().next();
     }

--- a/lib/round_manager.js
+++ b/lib/round_manager.js
@@ -4,17 +4,16 @@ const CompoThaSauceFetcher = require('../lib/compo_thasauce_fetcher');
 
 class RoundManager {
   constructor(roundId) {
+    let parentDir = `${path.dirname(__dirname)}/tmp/rounds/${roundId}`;
     this.roundId = roundId;
-    this.fetcher = new CompoThaSauceFetcher(roundId);
+    this.fetcher = new CompoThaSauceFetcher(roundId, parentDir);
     this.songs = null;
     this.currentSong = null;
 
-    let parentDir = `${path.dirname(__dirname)}/tmp/rounds/${roundId}`;
     this.dirs = {
       parent: parentDir,
       download: `${parentDir}/download`,
       transcode: `${parentDir}/transcode`,
-      final: `${parentDir}/final`,
       announcer: `${parentDir}/announcer`
     };
 
@@ -42,7 +41,7 @@ class RoundManager {
   }
 
   _makeDirectories() {
-    let dirs = [this.dirs.parent, this.dirs.download, this.dirs.transcode, this.dirs.final, this.dirs.announcer];
+    let dirs = [this.dirs.parent, this.dirs.download, this.dirs.transcode, this.dirs.announcer];
     dirs.forEach((dir) => {
       this._makeDirectoryIfItDoesntExist(dir);
     });

--- a/lib/round_manager.js
+++ b/lib/round_manager.js
@@ -1,17 +1,63 @@
 const fs = require('fs');
 const path = require('path');
 const mm = require('music-metadata');
+const zippa = require('zippa');
 
 const CompoThaSauceFetcher = require('./compo_thasauce_fetcher');
 const { metadataUpdater } = require('./machines');
 const { transcodeFinal } = require('../utils/symbols');
+
+function songExistsInArray(song, array) {
+  return array.some((item) => song.id === item.id);
+}
+
+function reconcileSongs(existingSongs, newSongs) {
+  let left = zippa.ArrayZipper.from(existingSongs).next();
+  let right = zippa.ArrayZipper.from(newSongs).next();
+
+  while (!left.isEnd() || !right.isEnd()) {
+    if (left.isEnd()) {
+      // There doesn't seem to be a way to recover from reaching the END of a
+      // zippa, so we'll construct the changes and make a new one!
+      left = zippa.ArrayZipper.from(left.value());
+
+      // If the left isn't empty...
+      if (left.down()) {
+        // We'll go into the array, all the way over to the right, and insert
+        // our new entry.
+        left = left.down().rightmost().insertRight(right.value());
+        // Finally, we'll get the zippa back to the END. (By going right once, to
+        // get to the newly inserted value, and then again to reach the END.)
+        left = left.next().next();
+      } else {
+        // Otherwise, we'll make a new zippa using an array of the new entry.
+        left = zippa.ArrayZipper.from([right.value()]);
+        // And reach the END again (right once for the value, right again for end)
+        left = left.next().next();
+      }
+      right = right.next();
+    } else if (right.isEnd()) {
+      left = left.remove().next();
+    } else if (left.item.id === right.item.id) {
+      left = left.next();
+      right = right.next();
+    } else if (songExistsInArray(left.value(), right.path.right)) {
+      left = left.insertLeft(right.value());
+      right = right.next();
+    } else {
+      left = left.remove().next();
+    }
+  }
+
+  return left.value();
+}
 
 class RoundManager {
   constructor(roundId) {
     let parentDir = `${path.dirname(__dirname)}/tmp/rounds/${roundId}`;
     this.roundId = roundId;
     this.fetcher = new CompoThaSauceFetcher(roundId, parentDir);
-    this.songs = null;
+    this.songs = [];
     this.currentSong = null;
 
     this.dirs = {
@@ -35,13 +81,9 @@ class RoundManager {
     return this.currentSong;
   }
 
-  async getAllSongs() {
-    if (this.songs) {
-      return this.songs;
-    }
-
-    let songs = await this.fetcher.fetch();
-    this.songs = songs;
+  async fetchAndReconcileAllSongs() {
+    let fetchedSongs = await this.fetcher.fetch();
+    this.songs = reconcileSongs(this.songs, fetchedSongs);
   }
 
   async transitionProcessedSongs() {

--- a/lib/round_transcoder.js
+++ b/lib/round_transcoder.js
@@ -8,6 +8,8 @@ const lame = require('lame');
 const mm = require('music-metadata');
 const soxCallback = require('sox.js');
 
+const { downloadFinal, transcodeFinal, transcodeIntermediate, transcodePcm } = require('../utils/symbols');
+
 const pipeline = util.promisify(stream.pipeline);
 const sox = util.promisify(soxCallback);
 
@@ -21,7 +23,9 @@ class RoundTranscoder {
       maxConcurrent: 3
     });
 
-    let transcoderPromises = this.roundManager.songs.map((song) => {
+    let songsToTranscode = this.roundManager.songs.filter((song) => song.service.state.matches('downloaded'));
+
+    let transcoderPromises = songsToTranscode.map((song) => {
       return limiter.schedule(() => this.transcodeSong(song));
     });
 
@@ -29,21 +33,13 @@ class RoundTranscoder {
   }
 
   async transcodeSong(song) {
-    let metadata = await mm.parseFile(song.paths.download);
+    let metadata = await mm.parseFile(song.path(downloadFinal));
 
-    // The eslint rule here is trying to prevent accidental race conditions,
-    // because we're accessing data on song and then setting it based on the
-    // result of the await here. This should be fine because we can't get to
-    // the transcode step until all of the download step is complete, and
-    // nothing can get the metadata until the entire transcode step is done.
-    // eslint-disable-next-line require-atomic-updates
-    song.metadata = metadata;
-
-    let pcmPath = `${this.roundManager.dirs.transcode}/${song.filename({ type: 'transcode-pcm' })}`;
-    let transcodePath = `${this.roundManager.dirs.transcode}/${song.filename()}`;
-    let finalPath = `${this.roundManager.dirs.final}/${song.filename()}`;
+    let pcmPath = song.path(transcodePcm);
+    let intermediatePath = song.path(transcodeIntermediate);
+    let finalPath = song.path(transcodeFinal);
     let soxParams = {
-      inputFile: song.paths.download,
+      inputFile: song.path(downloadFinal),
       input: {
         type: 'mp3'
       },
@@ -55,6 +51,8 @@ class RoundTranscoder {
         type: 'raw'
       }
     };
+
+    song.service.send('START_TRANSCODE');
 
     await sox(soxParams).catch((err) => {
       // If we get an error back from running sox (and it isn't just a warning)
@@ -81,7 +79,7 @@ class RoundTranscoder {
       outSampleRate: 44100,
       mode: lame.JOINTSTEREO
     });
-    let writeStream = fs.createWriteStream(transcodePath);
+    let writeStream = fs.createWriteStream(intermediatePath);
 
     await pipeline(
       readStream,
@@ -89,11 +87,10 @@ class RoundTranscoder {
       writeStream
     );
 
-    await fs.promises.rename(transcodePath, finalPath);
+    await fs.promises.rename(intermediatePath, finalPath);
     await fs.promises.unlink(pcmPath);
 
-    // eslint-disable-next-line require-atomic-updates
-    song.paths.final = finalPath;
+    song.service.send('FINISH_TRANSCODE', { metadata });
   }
 }
 

--- a/lib/round_transcoder.js
+++ b/lib/round_transcoder.js
@@ -5,7 +5,6 @@ const util = require('util');
 const Promise = require('bluebird');
 const Bottleneck = require('bottleneck');
 const lame = require('lame');
-const mm = require('music-metadata');
 const soxCallback = require('sox.js');
 
 const { downloadFinal, transcodeFinal, transcodeIntermediate, transcodePcm } = require('../utils/symbols');
@@ -33,8 +32,6 @@ class RoundTranscoder {
   }
 
   async transcodeSong(song) {
-    let metadata = await mm.parseFile(song.path(downloadFinal));
-
     let pcmPath = song.path(transcodePcm);
     let intermediatePath = song.path(transcodeIntermediate);
     let finalPath = song.path(transcodeFinal);
@@ -90,7 +87,7 @@ class RoundTranscoder {
     await fs.promises.rename(intermediatePath, finalPath);
     await fs.promises.unlink(pcmPath);
 
-    song.service.send('FINISH_TRANSCODE', { metadata });
+    song.service.send('FINISH_TRANSCODE');
   }
 }
 

--- a/lib/song.js
+++ b/lib/song.js
@@ -90,7 +90,7 @@ class Song {
         return;
       }
 
-      let statement = `[Song->${state.value}] Song #${this.id}`;
+      let statement = `[Song->${state.value}] Song #${this.id} - ${this.title}`;
       if (successStates.includes(state.value)) {
         statement = statement.success;
       } else {

--- a/lib/song.js
+++ b/lib/song.js
@@ -1,6 +1,8 @@
+const fs = require('fs');
 const path = require('path');
-const { createMachine, interpret } = require('xstate');
-const { assign } = require('@xstate/immer');
+const { interpret } = require('xstate');
+
+const { songMachine } = require('./machines');
 
 const {
   announcerAws,
@@ -21,66 +23,14 @@ let successStates = [
   'ready'
 ];
 
-// TODO: allow transitioning from fetched directly into a later state if we have
-// the requisite final file for download, transcode, or announcer
-let songMachine = createMachine({
-  initial: 'init',
-  context: {},
-  states: {
-    init: {
-      on: {
-        FETCH_FINISH: {
-          target: 'fetched',
-          actions: ['storeFetchedData']
-        }
-      }
-    },
-    fetched: {
-      on: {
-        START_DOWNLOAD: 'downloading'
-      }
-    },
-    downloading: {
-      on: {
-        FINISH_DOWNLOAD: 'downloaded'
-      }
-    },
-    downloaded: {
-      on: {
-        START_TRANSCODE: 'transcoding'
-      }
-    },
-    transcoding: {
-      on: {
-        FINISH_TRANSCODE: {
-          target: 'transcoded',
-          actions: ['storeMetadata']
-        }
-      }
-    },
-    transcoded: {
-      on: {
-        START_ANNOUNCER_DL_AND_TRANSCODE: 'announcerProcessing'
-      }
-    },
-    announcerProcessing: {
-      on: {
-        FINISH_ANNOUNCER_DL_AND_TRANSCODE: 'ready'
-      }
-    },
-    ready: {}
+async function fileExists(path) {
+  try {
+    await fs.promises.access(path, fs.constants.F_OK);
+    return true;
+  } catch(e) {
+    return false;
   }
-}, {
-  actions: {
-    storeFetchedData: assign((context, event) => {
-      context.id = event.songId;
-      context.title = event.title;
-      context.artist = event.artist;
-      context.url = event.url;
-    }),
-    storeMetadata: assign((context, event) => context.metadata = event.metadata)
-  }
-});
+}
 
 class Song {
   constructor(directory) {
@@ -90,7 +40,7 @@ class Song {
         return;
       }
 
-      let statement = `[Song->${state.value}] Song #${this.id} - ${this.title}`;
+      let statement = `[Song->${state.value}](${state.event.type}) Song #${this.id} - ${this.title}`;
       if (successStates.includes(state.value)) {
         statement = statement.success;
       } else {
@@ -159,6 +109,19 @@ class Song {
         return `${this.id}-transcode-intermediate.mp3`;
       case transcodePcm:
         return `${this.id}-transcode-pcm.pcm`;
+    }
+  }
+
+  // If we have any final files from the stages of processing, we can likely
+  // skip some states of processing!
+  async transitionIfProcessed() {
+    let finalDownloadExists = await fileExists(this.path(downloadFinal));
+    let finalTranscodeExists = await fileExists(this.path(transcodeFinal));
+
+    if (finalTranscodeExists) {
+      this.service.send('SKIP_TRANSCODE');
+    } else if (finalDownloadExists) {
+      this.service.send('SKIP_DOWNLOAD');
     }
   }
 }

--- a/lib/song.js
+++ b/lib/song.js
@@ -1,29 +1,164 @@
-class Song {
-  constructor({ id, title, artist, url }) {
-    this.id = id;
-    this.title = title;
-    this.artist = artist;
-    this.url = url;
-    this.metadata = null;
+const path = require('path');
+const { createMachine, interpret } = require('xstate');
+const { assign } = require('@xstate/immer');
 
-    this.paths = {
-      download: null,
-      transcode: null,
-      final: null,
-      announcer: null
-    };
+const {
+  announcerAws,
+  announcerFinal,
+  announcerIntermediate,
+  announcerPcm,
+  downloadFinal,
+  downloadIntermediate,
+  transcodeFinal,
+  transcodeIntermediate,
+  transcodePcm
+} = require('../utils/symbols');
+
+let successStates = [
+  'fetched',
+  'downloaded',
+  'transcoded',
+  'ready'
+];
+
+// TODO: allow transitioning from fetched directly into a later state if we have
+// the requisite final file for download, transcode, or announcer
+let songMachine = createMachine({
+  initial: 'init',
+  context: {},
+  states: {
+    init: {
+      on: {
+        FETCH_FINISH: {
+          target: 'fetched',
+          actions: ['storeFetchedData']
+        }
+      }
+    },
+    fetched: {
+      on: {
+        START_DOWNLOAD: 'downloading'
+      }
+    },
+    downloading: {
+      on: {
+        FINISH_DOWNLOAD: 'downloaded'
+      }
+    },
+    downloaded: {
+      on: {
+        START_TRANSCODE: 'transcoding'
+      }
+    },
+    transcoding: {
+      on: {
+        FINISH_TRANSCODE: {
+          target: 'transcoded',
+          actions: ['storeMetadata']
+        }
+      }
+    },
+    transcoded: {
+      on: {
+        START_ANNOUNCER_DL_AND_TRANSCODE: 'announcerProcessing'
+      }
+    },
+    announcerProcessing: {
+      on: {
+        FINISH_ANNOUNCER_DL_AND_TRANSCODE: 'ready'
+      }
+    },
+    ready: {}
+  }
+}, {
+  actions: {
+    storeFetchedData: assign((context, event) => {
+      context.id = event.songId;
+      context.title = event.title;
+      context.artist = event.artist;
+      context.url = event.url;
+    }),
+    storeMetadata: assign((context, event) => context.metadata = event.metadata)
+  }
+});
+
+class Song {
+  constructor(directory) {
+    this.directory = directory;
+    this.service = interpret(songMachine).onTransition((state) => {
+      if (state.value === 'init') {
+        return;
+      }
+
+      let statement = `[Song->${state.value}] Song #${this.id}`;
+      if (successStates.includes(state.value)) {
+        statement = statement.success;
+      } else {
+        statement = statement.info;
+      }
+
+      console.info(statement);
+    });
+    this.service.start();
   }
 
-  filename({ type } = { type: 'final' }) {
+  get id() {
+    return this.service.state.context.id;
+  }
+
+  get title() {
+    return this.service.state.context.title;
+  }
+
+  get artist() {
+    return this.service.state.context.artist;
+  }
+
+  get url() {
+    return this.service.state.context.url;
+  }
+
+  get metadata() {
+    return this.service.state.context.metadata;
+  }
+
+  path(type) {
     switch (type) {
-      case 'transcode-pcm':
-        return `${this.id}.pcm`;
-      case 'announcer-aws':
-        return `${this.id}-aws.mp3`;
-      case 'announcer-pcm':
-        return `${this.id}-aws.pcm`;
-      default:
-        return `${this.id}.mp3`;
+      case announcerAws:
+      case announcerFinal:
+      case announcerIntermediate:
+      case announcerPcm:
+        return path.join(this.directory, 'announcer', this.filename(type));
+      case downloadFinal:
+      case downloadIntermediate:
+        return path.join(this.directory, 'download', this.filename(type));
+      case transcodeFinal:
+      case transcodeIntermediate:
+      case transcodePcm:
+        return path.join(this.directory, 'transcode', this.filename(type));
+    }
+  }
+
+  filename(type) {
+    switch (type) {
+      case announcerAws:
+        return `${this.id}-announcer-aws.mp3`;
+      case announcerFinal:
+        return `${this.id}-announcer.mp3`;
+      case announcerIntermediate:
+        return `${this.id}-announcer-intermediate.mp3`;
+      case announcerPcm:
+        return `${this.id}-announcer-pcm.pcm`;
+      case downloadFinal:
+        return `${this.id}-download.mp3`;
+      case downloadIntermediate:
+        return `${this.id}-download-intermediate.mp3`;
+      case transcodeFinal:
+        return `${this.id}-transcode.mp3`;
+      case transcodeIntermediate:
+        return `${this.id}-transcode-intermediate.mp3`;
+      case transcodePcm:
+        return `${this.id}-transcode-pcm.pcm`;
     }
   }
 }

--- a/lib/song.js
+++ b/lib/song.js
@@ -118,6 +118,8 @@ class Song {
     let finalDownloadExists = await fileExists(this.path(downloadFinal));
     let finalTranscodeExists = await fileExists(this.path(transcodeFinal));
 
+    // We're not going to skip generating the announcer, even if we have the
+    // final mp3, because the title may have changed.
     if (finalTranscodeExists) {
       this.service.send('SKIP_TRANSCODE');
     } else if (finalDownloadExists) {

--- a/lib/stream_manager.js
+++ b/lib/stream_manager.js
@@ -3,7 +3,6 @@ const stream = require('stream');
 const util = require('util');
 const EventEmitter = require('events');
 const nodeshout = require('nodeshout');
-const Promise = require('bluebird');
 
 const RoundAnnouncer = require('../lib/round_announcer');
 const RoundFetcher = require('../lib/round_fetcher');
@@ -54,6 +53,11 @@ class StreamManager extends EventEmitter {
       return;
     }
 
+    await this.roundManager.transitionProcessedSongs();
+    if (this.stopped) {
+      return;
+    }
+
     this.emit('fetchingSongs');
     await this.roundFetcher.fetch();
     if (this.stopped) {
@@ -62,6 +66,11 @@ class StreamManager extends EventEmitter {
 
     this.emit('transcodingSongs');
     await this.roundTranscoder.transcode();
+    if (this.stopped) {
+      return;
+    }
+
+    await this.roundManager.parseMetadata();
     if (this.stopped) {
       return;
     }

--- a/lib/stream_manager.js
+++ b/lib/stream_manager.js
@@ -123,6 +123,15 @@ class StreamManager extends EventEmitter {
     await pipeline(this.fileStream, this.shoutStream);
   }
 
+  async refetch() {
+    await this.roundManager.fetchAndReconcileAllSongs();
+    await this.roundManager.transitionProcessedSongs();
+    await this.roundFetcher.fetch();
+    await this.roundTranscoder.transcode();
+    await this.roundManager.parseMetadata();
+    await this.roundAnnouncer.process();
+  }
+
   skipSong() {
     this._stopCurrentSong();
   }

--- a/lib/stream_manager.js
+++ b/lib/stream_manager.js
@@ -48,7 +48,7 @@ class StreamManager extends EventEmitter {
     this._shout.setAudioInfo('channels', '2');
 
     this.emit('compoMetadataFetching');
-    await this.roundManager.getAllSongs();
+    await this.roundManager.fetchAndReconcileAllSongs();
     if (this.stopped) {
       return;
     }

--- a/lib/stream_manager.js
+++ b/lib/stream_manager.js
@@ -1,11 +1,13 @@
 const EventEmitter = require('events');
 const nodeshout = require('nodeshout');
 const Promise = require('bluebird');
+
 const RoundAnnouncer = require('../lib/round_announcer');
 const RoundFetcher = require('../lib/round_fetcher');
 const RoundManager = require('../lib/round_manager');
 const RoundTranscoder = require('../lib/round_transcoder');
 const fetchEnv = require('../utils/fetch-env');
+const { announcerFinal, transcodeFinal } = require('../utils/symbols');
 
 const fs = require('fs');
 
@@ -103,7 +105,7 @@ class StreamManager extends EventEmitter {
   }
 
   async playSong(song) {
-    this.fileStream = fs.createReadStream(song.paths.announcer, { highWaterMark: 65536 });
+    this.fileStream = fs.createReadStream(song.path(announcerFinal), { highWaterMark: 65536 });
     this.shoutStream = new ShoutStream(this._shout);
 
     this.emit('playing', song);
@@ -111,7 +113,7 @@ class StreamManager extends EventEmitter {
     return new Promise((resolve) => {
       let announcerStream = this.fileStream.pipe(this.shoutStream);
       announcerStream.on('finish', () => {
-        this.fileStream = fs.createReadStream(song.paths.final, { highWaterMark: 65536 });
+        this.fileStream = fs.createReadStream(song.path(transcodeFinal), { highWaterMark: 65536 });
         this.shoutStream = new ShoutStream(this._shout);
 
         let songStream = this.fileStream.pipe(this.shoutStream);

--- a/lib/stream_manager.js
+++ b/lib/stream_manager.js
@@ -1,3 +1,6 @@
+const fs = require('fs');
+const stream = require('stream');
+const util = require('util');
 const EventEmitter = require('events');
 const nodeshout = require('nodeshout');
 const Promise = require('bluebird');
@@ -9,9 +12,8 @@ const RoundTranscoder = require('../lib/round_transcoder');
 const fetchEnv = require('../utils/fetch-env');
 const { announcerFinal, transcodeFinal } = require('../utils/symbols');
 
-const fs = require('fs');
-
 const { ShoutStream } = nodeshout;
+const pipeline = util.promisify(stream.pipeline);
 
 nodeshout.init();
 
@@ -93,15 +95,9 @@ class StreamManager extends EventEmitter {
   async playIntro() {
     this.fileStream = fs.createReadStream('./music/intro.mp3', { highWaterMark: 65536 });
     this.shoutStream = new ShoutStream(this._shout);
-    let songStream = this.fileStream.pipe(this.shoutStream);
 
     this.emit('intro');
-
-    return new Promise(function(resolve) {
-      songStream.on('finish', function() {
-        resolve();
-      });
-    });
+    await pipeline(this.fileStream, this.shoutStream);
   }
 
   async playSong(song) {
@@ -110,19 +106,12 @@ class StreamManager extends EventEmitter {
 
     this.emit('playing', song);
 
-    return new Promise((resolve) => {
-      let announcerStream = this.fileStream.pipe(this.shoutStream);
-      announcerStream.on('finish', () => {
-        this.fileStream = fs.createReadStream(song.path(transcodeFinal), { highWaterMark: 65536 });
-        this.shoutStream = new ShoutStream(this._shout);
+    await pipeline(this.fileStream, this.shoutStream);
 
-        let songStream = this.fileStream.pipe(this.shoutStream);
+    this.fileStream = fs.createReadStream(song.path(transcodeFinal), { highWaterMark: 65536 });
+    this.shoutStream = new ShoutStream(this._shout);
 
-        songStream.on('finish', () => {
-          resolve();
-        });
-      });
-    });
+    await pipeline(this.fileStream, this.shoutStream);
   }
 
   skipSong() {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "nodeshout": "^0.1.3",
     "sox.js": "^2.1.0",
     "streamifier": "^0.1.1",
-    "xstate": "^4.10.0"
+    "xstate": "^4.10.0",
+    "zippa": "^0.3.1"
   },
   "engines": {
     "node": "10"

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "bottleneck": "^2.19.5",
     "cheerio": "^1.0.0-rc.3",
     "colors": "^1.4.0",
+    "commando-provider-keyv": "^2.1.0",
     "discord.js": "11.6.4",
     "discord.js-commando": "^0.10.0",
     "immer": "^6.0.9",

--- a/utils/symbols.js
+++ b/utils/symbols.js
@@ -1,0 +1,21 @@
+let announcerAws = Symbol('announcerAws');
+let announcerFinal = Symbol('announcerFinal');
+let announcerIntermediate = Symbol('announcerIntermediate');
+let announcerPcm = Symbol('announcerPcm');
+let downloadFinal = Symbol('downloadFinal');
+let downloadIntermediate = Symbol('downloadIntermediate');
+let transcodeFinal = Symbol('transcodeFinal');
+let transcodeIntermediate = Symbol('transcodeIntermediate');
+let transcodePcm = Symbol('transcodePcm');
+
+module.exports = {
+  announcerAws,
+  announcerFinal,
+  announcerIntermediate,
+  announcerPcm,
+  downloadFinal,
+  downloadIntermediate,
+  transcodeFinal,
+  transcodeIntermediate,
+  transcodePcm
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -282,6 +282,11 @@ colors@^1.4.0:
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
   integrity sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==
 
+commando-provider-keyv@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/commando-provider-keyv/-/commando-provider-keyv-2.1.0.tgz#7530494376701be85325dd1d4595398dd4e3b18f"
+  integrity sha512-qxs+7WJy+2B7KzH7aBCY8NEgEUGmvbIvRwhBAXfFwhMzNd2DLr/nGyy+iUJ0MCBTYLSSLvea1tii9fLrlCj7ZQ==
+
 common-tags@^1.0.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/common-tags/-/common-tags-1.8.0.tgz#8e3153e542d4a39e9b10554434afaaf98956a937"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1111,6 +1111,11 @@ querystring@0.2.0:
   resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
   integrity sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=
 
+ramda@^0.21.0:
+  version "0.21.0"
+  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.21.0.tgz#a001abedb3ff61077d4ff1d577d44de77e8d0a35"
+  integrity sha1-oAGr7bP/YQd9T/HVd9RN536NCjU=
+
 readable-stream@^1.0.34:
   version "1.1.14"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.1.14.tgz#7cf4c54ef648e3813084c636dd2079e166c081d9"
@@ -1507,3 +1512,10 @@ xstate@^4.10.0:
   version "4.10.0"
   resolved "https://registry.yarnpkg.com/xstate/-/xstate-4.10.0.tgz#f87e4ef593fe40300b8eec50a5d9f0763aa4f622"
   integrity sha512-nncQ9gW+xgk5iUEvpBOXhbzSCS0uwzzT4bOAXxo6oUoALgbxzqEyMmaMYwuvOHrabDTdMJYnF+xe2XD8RRgWmA==
+
+zippa@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/zippa/-/zippa-0.3.1.tgz#27d18e8f93ba0a87ae04678c30fa6be38f119a1b"
+  integrity sha1-J9GOj5O6CoeuBGeMMPpr448Rmhs=
+  dependencies:
+    ramda "^0.21.0"


### PR DESCRIPTION
This rewrites a lot of the internals so that songs have a state machine, and we can track exactly how each song has been processed. It introduces a refetch command that refetches the round, a reconciliation algorithm to incorporate any new songs (or removed songs) into the songs list, and processes just the new songs.

There's some related refactoring to use promises and pipelines, and we introduced some basic error handing to report back to the user in discord if there was a JS error while trying to execute their command.

Fixes #15 