### PR TITLE
Escape song title and artist when using it in a discord message

### DIFF
--- a/commands/compoverse/playlist.js
+++ b/commands/compoverse/playlist.js
@@ -28,7 +28,7 @@ module.exports = class PlaylistCommand extends Command {
       if (current && current.song.id === song.id) {
         msg = msg.concat('**');
       }
-      msg = msg.concat(`${index + 1}. ${song.title}`);
+      msg = msg.concat(`${index + 1}. ${song.safeTitle}`);
       if (current && current.song.id === song.id) {
         msg = msg.concat('**');
       }

--- a/commands/compoverse/startparty.js
+++ b/commands/compoverse/startparty.js
@@ -59,12 +59,12 @@ module.exports = class StartPartyCommand extends Command {
 
       const embed = new MessageEmbed()
         .setColor('#39aa6e')
-        .setTitle(song.title)
+        .setTitle(song.safeTitle)
         .setDescription(`Entry ${position} of ${current.total}`)
-        .addField('Artist', song.artist)
+        .addField('Artist', song.safeArtist)
         .addField('Length', length);
 
-      message.say(`Now Playing: ${song.title} by ${song.artist} [${length}]`);
+      message.say(`Now Playing: ${song.safeTitle} by ${song.safeArtist} [${length}]`);
       message.embed(embed);
     });
 

--- a/index.js
+++ b/index.js
@@ -60,7 +60,10 @@ client.dispatcher.addInhibitor((message) => {
   if (message.command.group.id === 'compoverse') {
     let authorized = memberHasOneOfTheseRoles(message.member, [roleIds.thasauceAdmin, roleIds.compoAdmin]);
     if (!authorized) {
-      return ['not-allowed', message.reply('you\'re not allowed to run compoverse commands')];
+      return {
+        reason: 'not-allowed',
+        response: message.reply('you\'re not allowed to run compoverse commands')
+      };
     }
   }
 

--- a/lib/song.js
+++ b/lib/song.js
@@ -3,6 +3,7 @@ const path = require('path');
 const { interpret } = require('xstate');
 
 const { songMachine } = require('./machines');
+const { escapeDiscordMarkdown } = require('../utils/markdown');
 
 const {
   announcerAws,
@@ -60,8 +61,18 @@ class Song {
     return this.service.state.context.title;
   }
 
+  // Returns a title that has any discord formatting markdown escaped
+  get safeTitle() {
+    return escapeDiscordMarkdown(this.title);
+  }
+
   get artist() {
     return this.service.state.context.artist;
+  }
+
+  // Returns an artist that has any discord formatting markdown escaped
+  get safeArtist() {
+    return escapeDiscordMarkdown(this.artist);
   }
 
   get url() {

--- a/utils/markdown.js
+++ b/utils/markdown.js
@@ -1,0 +1,7 @@
+const unsafeCharactersRegex = /([*_\\|`~])/g;
+
+function escapeDiscordMarkdown(input) {
+  return input.replace(unsafeCharactersRegex, '\\$1');
+}
+
+module.exports = { escapeDiscordMarkdown };


### PR DESCRIPTION
This escapes any discord formatting markdown before we use a song title or artist in a discord message.

Fixes #281 