### PR TITLE
Fix song titles that are just numbers

### DIFF
--- a/lib/compo_thasauce_fetcher.js
+++ b/lib/compo_thasauce_fetcher.js
@@ -28,13 +28,20 @@ class CompoThaSauceFetcher {
     let songs = items.toArray().map((item) => {
       let $item = $(item);
       let songDownloadAnchor = $item.find('.song-download');
-
       let song = new Song(this.parentDir);
+
+      // Handle if we couldn't get a data attribute by providing an empty string as default
+      let songId = $item.data('id') || '';
+      let title = $item.data('title') || '';
+      let artist = $item.data('author') || '';
+      let url = ROOT_URL + songDownloadAnchor.attr('href');
+
+      // cheerio.data can return a number or string, so this makes sure we only deal with strings
       let event = {
-        songId: $item.data('id'),
-        title: $item.data('title'),
-        artist: $item.data('author'),
-        url: ROOT_URL + songDownloadAnchor.attr('href')
+        songId: songId.toString(),
+        title: title.toString(),
+        artist: artist.toString(),
+        url
       };
       song.service.send('FETCH_FINISH', event);
       return song;

--- a/lib/song.js
+++ b/lib/song.js
@@ -42,6 +42,7 @@ class Song {
         return;
       }
 
+      console.log('Received event: ', state.event);
       let statement = `[Song->${state.value}](${state.event.type}) Song #${this.id} - ${this.title}`;
       if (successStates.includes(state.value)) {
         log(statement, 'success');


### PR DESCRIPTION
Cheerio's `data()` function can return a Number if the characters are all numbers, instead of a String. This ensures that we are smart about defaults and transformation so that all the song attributes are always strings.