### PR TITLE
Remove erlpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "discord.js": "12.5.1",
     "discord.js-commando": "^0.11.1",
     "dotenv": "^10.0.0",
-    "erlpack": "discord/erlpack",
     "ffmpeg-static": "^4.4.0",
     "got": "^11.8.2",
     "immer": "^9.0.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -365,15 +365,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bindings@npm:^1.5.0":
-  version: 1.5.0
-  resolution: "bindings@npm:1.5.0"
-  dependencies:
-    file-uri-to-path: 1.0.0
-  checksum: 65b6b48095717c2e6105a021a7da4ea435aa8d3d3cd085cb9e85bcb6e5773cf318c4745c3f7c504412855940b585bdf9b918236612a1c7a7942491de176f1ae7
-  languageName: node
-  linkType: hard
-
 "bluebird@npm:^3.7.2":
   version: 3.7.2
   resolution: "bluebird@npm:3.7.2"
@@ -568,7 +559,6 @@ __metadata:
     discord.js: 12.5.1
     discord.js-commando: ^0.11.1
     dotenv: ^10.0.0
-    erlpack: discord/erlpack
     eslint: ^8.2.0
     eslint-config-prettier: ^8.3.0
     ffmpeg-static: ^4.4.0
@@ -961,16 +951,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-erlpack@discord/erlpack:
-  version: 0.1.3
-  resolution: "erlpack@https://github.com/discord/erlpack.git#commit=f7d730debe32c416d1b55b4217f8aef2ade05874"
-  dependencies:
-    bindings: ^1.5.0
-    nan: ^2.15.0
-  checksum: 37d85a27f0e15c7cc10f5b605e7b860d38a291f616dadb1e2ff2a49215c56fa8724ca53923615e355229c85cc84713c762b04f8038f74789ce8e52504eaf7e1f
-  languageName: node
-  linkType: hard
-
 "err-code@npm:^2.0.2":
   version: 2.0.3
   resolution: "err-code@npm:2.0.3"
@@ -1256,13 +1236,6 @@ erlpack@discord/erlpack:
     strtok3: ^6.2.4
     token-types: ^4.1.1
   checksum: 38a4443d0f7b9b3de8a44a1d75d441f9ddb544a1adbf22ec7bc07d135452c3464000c64daa51220ffec6a38ceec7565a1290337bd81aab2e6273c79db5ed9ef3
-  languageName: node
-  linkType: hard
-
-"file-uri-to-path@npm:1.0.0":
-  version: 1.0.0
-  resolution: "file-uri-to-path@npm:1.0.0"
-  checksum: b648580bdd893a008c92c7ecc96c3ee57a5e7b6c4c18a9a09b44fb5d36d79146f8e442578bc0e173dc027adf3987e254ba1dfd6e3ec998b7c282873010502144
   languageName: node
   linkType: hard
 
@@ -2119,7 +2092,7 @@ erlpack@discord/erlpack:
   languageName: node
   linkType: hard
 
-"nan@npm:^2.14.0, nan@npm:^2.15.0":
+"nan@npm:^2.14.0":
   version: 2.15.0
   resolution: "nan@npm:2.15.0"
   dependencies:


### PR DESCRIPTION
erlpack continues to have problems in node v16 and building for heroku, so I'm removing it.