### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   lint_build_test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/fusion2004/chorus/security/code-scanning/1](https://github.com/fusion2004/chorus/security/code-scanning/1)

Add an explicit `permissions` block in `.github/workflows/ci.yml` to enforce least privilege for the workflow/job.

Best fix here (without changing functionality): define workflow-level permissions right after the trigger block (`on:`), with `contents: read`. This is sufficient for `actions/checkout` and typical lint/build/test steps that do not need write scopes. Workflow-level placement applies to all jobs unless overridden, keeping config simple and secure.

File/region to change:
- `.github/workflows/ci.yml` near lines 8–9, between `on:` and `jobs:`.

No imports, methods, or dependencies are needed (YAML config change only).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
