### PR TITLE
Delete .github/dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: npm
-    directory: '/'
-    schedule:
-      interval: daily
-      time: '10:00'
-    open-pull-requests-limit: 99


### PR DESCRIPTION
We no longer want dependabot PRs now that renovate is configured