### PR TITLE
Move localhost Icecast vars into mise.development.toml

### DIFF
--- a/mise.development.toml
+++ b/mise.development.toml
@@ -1,0 +1,8 @@
+[env]
+# Loaded only when MISE_ENV=development.
+# These point at a local Icecast for the dev loop;
+# real deployments override every one of these via platform config vars.
+HUBOT_STREAM_HOST = "localhost"
+HUBOT_STREAM_MOUNT = "compo"
+HUBOT_STREAM_PORT = "8000"
+ICECAST_ORIGIN = "http://localhost:8000"

--- a/mise.toml
+++ b/mise.toml
@@ -7,10 +7,6 @@ yarn = "4.14.1"
 # Per-developer values (secrets, IDs) go in mise.local.toml.
 AWS_NODEJS_CONNECTION_REUSE_ENABLED = "1"
 AWS_REGION = "us-east-1"
-HUBOT_STREAM_HOST = "localhost"
-HUBOT_STREAM_MOUNT = "compo"
-HUBOT_STREAM_PORT = "8000"
-ICECAST_ORIGIN = "http://localhost:8000"
 
 [tasks.dev]
 description = "Live-reload dev server"


### PR DESCRIPTION
These were leaking into Railway via mise.toml's [env] block. The new file only loads when MISE_ENV=development, keeping the values handy locally without polluting deployed environments.